### PR TITLE
Add sample kubernetes deployment

### DIFF
--- a/kubernetes/falco.yaml
+++ b/kubernetes/falco.yaml
@@ -1,0 +1,9 @@
+# This is not the full falco.yaml just the program_output config
+program_output:
+  enabled: true
+  keep_alive: false
+  program: "curl -d @- falcosidekick.sysdig-staging.svc.cluster.local:2801/"
+
+# Other Notes:
+# * Don't forget to whitelist proc.cmdline = "curl -d @- falcosidekick.sysdig-staging.svc.cluster.local:2801/" for the rule "Command Ran in Container"
+# * Don't forget to whitelist the falcosidekick container reaching out to datadog CIDRs.

--- a/kubernetes/falcosidekick-deployment.yaml
+++ b/kubernetes/falcosidekick-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccount: falcosidekick
       containers:
         - name: falcosidekick
-          image: issif/falcosidekick:1.0.7
+          image: issif/falcosidekick:1.1.0
           imagePullPolicy: Always
           ports:
           - containerPort: 2081
@@ -50,12 +50,12 @@ spec:
           # CREATE THE K8S SECRETS BEFORE UNCOMMENTING
           # https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-using-kubectl-create-secret
           # Example: kubectl create secret falcosidekick-slack-secret --from-file=./slack-secret.txt 
-          # - name: SLACK_TOKEN
+          # - name: SLACK_WEBHOOK_URL
           #   valueFrom:
           #     secretKeyRef:
           #       name: falcosidekick-slack-secret
           #       key: slack_webhook_url
-          # - name: DATADOG_TOKEN
+          # - name: DATADOG_API_KEY
           #   valueFrom:
           #     secretKeyRef:
           #       name: falcosidekick-datadog-secret
@@ -64,11 +64,11 @@ spec:
             value: ""
           - name: SLACK_ICON
             value: ""
+          - name: SLACK_OUTPUT_FORMAT
+            value: "all"
           - name: DEBUG
             value: "true"
-          args: [ "/falcosidekick",
-                  "-e", "SLACK_TOKEN=$(SLACK_TOKEN)",
-                  "-e", "DATADOG_TOKEN=$(DATADOG_TOKEN)"]
+          args: [ "/falcosidekick"]
           readinessProbe:
             httpGet:
               path: "/ping"

--- a/kubernetes/falcosidekick-deployment.yaml
+++ b/kubernetes/falcosidekick-deployment.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: falcosidekick
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: falcosidekick
+  labels:
+    name: falcosidekick
+spec: 
+  ports:
+  - port: 2801
+    protocol: TCP
+    targetPort: 2801
+  selector:
+    name: falcosidekick
+  type: ClusterIP
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: falcosidekick
+  labels:
+    name: falcosidekick
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: falcosidekick
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: falcosidekick
+    spec:
+      serviceAccount: falcosidekick
+      containers:
+        - name: falcosidekick
+          image: issif/falcosidekick:1.0.7
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 2081
+            name: svc-port
+          env:
+          # CREATE THE K8S SECRETS BEFORE UNCOMMENTING
+          # https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-using-kubectl-create-secret
+          # Example: kubectl create secret falcosidekick-slack-secret --from-file=./slack-secret.txt 
+          # - name: SLACK_TOKEN
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: falcosidekick-slack-secret
+          #       key: slack_webhook_url
+          # - name: DATADOG_TOKEN
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: falcosidekick-datadog-secret
+          #       key: datadog_api_key
+          - name: SLACK_FOOTER
+            value: ""
+          - name: SLACK_ICON
+            value: ""
+          - name: DEBUG
+            value: "true"
+          args: [ "/falcosidekick",
+                  "-e", "SLACK_TOKEN=$(SLACK_TOKEN)",
+                  "-e", "DATADOG_TOKEN=$(DATADOG_TOKEN)"]
+          readinessProbe:
+            httpGet:
+              path: "/ping"
+              port: 2801
+            initialDelaySeconds: 20
+            periodSeconds: 3
+


### PR DESCRIPTION
Adding a Kubernetes Deployment manifest that can be used to deploy falcosidekick to a Kubernetes environment.

Verified deployment works on Minikube.
![image](https://user-images.githubusercontent.com/6011550/57406940-03983400-71b0-11e9-9776-35ffc1ddce1a.png)


cc @Issif 
