### PR TITLE
Don't produce duplicate entries when events have non-string fields

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -26,6 +26,8 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPaylo
 		case string:
 			//AlertManger doesn't support dots in a label name
 			amPayload.Labels[strings.Replace(i, ".", "_", -1)] = j.(string)
+		default:
+			continue
 		}
 	}
 	amPayload.Labels["source"] = "falco"

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
-var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule", "time":"2001-01-01T01:10:00Z","output_fields": {"proc.name":"falcosidekick","user.name":"falcosidekick"}}`
+var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule", "time":"2001-01-01T01:10:00Z","output_fields": {"proc.name":"falcosidekick","user.name":"falcosidekick", "proc.tty": 1234}}`
 
 func TestNewClient(t *testing.T) {
 	u, _ := url.Parse("http://localhost")

--- a/outputs/slack.go
+++ b/outputs/slack.go
@@ -47,6 +47,8 @@ func newSlackPayload(falcopayload types.FalcoPayload, config *types.Configuratio
 				} else {
 					field.Short = false
 				}
+			default:
+				continue
 			}
 			fields = append(fields, field)
 		}

--- a/outputs/teams.go
+++ b/outputs/teams.go
@@ -50,6 +50,8 @@ func newTeamsPayload(falcopayload types.FalcoPayload, config *types.Configuratio
 			case string:
 				fact.Name = i
 				fact.Value = j.(string)
+			default:
+				continue
 			}
 			facts = append(facts, fact)
 		}


### PR DESCRIPTION
Falco emits events that include non-string fields (like `proc.tty`). When some outputs encountered these fields, they would re-append the previous string field because the variable was reused. This resulted in duplicated fields in the output. This PR drops the numeric fields for now and fixes the duplicated fields.