### PR TITLE
Add format string for Slack outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ slack:
   #icon: "" # Slack icon (avatar)
   outputformat: "text" # all (default), text, fields
   minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)
+  messageformat: "Alert for rule '{{ .Rule }}' from process {{ index .OutputFields \"proc.name\" }} " # a Go template to format Slack messages, see Slack Message Formatting in the README for details
 
 teams:
   webhookurl: "" # Teams WebhookURL (ex: https://hooks.slack.com/services/XXXX/YYYY/ZZZZ), if not empty, Teams output is enabled
@@ -166,6 +167,7 @@ The *env vars* "match" field names in *yaml file with this structure (**take car
 * **SLACK_ICON** : Slack icon (avatar)
 * **SLACK_OUTPUTFORMAT** : `all` (default), `text` (only text is displayed in Slack), `fields` (only fields are displayed in Slack)
 * **SLACK_MINIMUMPRIORITY** : minimum priority of event for using use this output, order is `emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)`
+* **SLACK_MESSAGEFORMAT** : a Go template to format Slack alert messages. This is displayed in addition to the output from `SLACK_OUTPUTFORMAT`. See [Slack Message Formatting](#slack-message-formatting) for details.
 * **TEAMS_WEBHOOKURL** : Teams Webhook URL (ex: https://outlook.office.com/webhook/XXXXXX/IncomingWebhook/YYYYYY"), if not `empty`, Teams output is *enabled*
 * **TEAMS_ACTIVITYIMAGE** : Teams section image
 * **TEAMS_OUTPUTFORMAT** : `all` (default), `text` (only text is displayed in Teams), `facts` (only facts are displayed in Teams)
@@ -205,6 +207,20 @@ The *env vars* "match" field names in *yaml file with this structure (**take car
 * **OPSGENIE_APIKEY** : Opsgenie API Key, if not empty, Opsgenie output is enabled
 * **OPSGENIE_REGION** : "" # (us|eu) region of your domain (default is 'us')
 * **OPSGENIE_MINIMUMPRIORITY** : minimum priority of event for using this output, order is `emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)`
+
+#### Slack Message Formatting
+
+The `SLACK_MESSAGEFORMAT` environment variable and `slack.messageformat` YAML value accept a [Go template](https://golang.org/pkg/text/template/) which can be used to format the text of a slack alert. These templates are evaluated on the JSON data from each Falco event - the following fields are available:
+                                                                                                                   
+| Template Syntax                              | Description      |
+|----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `{{ .Output }}`                              | A formatted string from Falco describing the event.                                                                                                      |
+| `{{ .Priority }}`                            | The priority of the event, as a string.                                                                                                                  |
+| `{{ .Rule }}`                                | The name of the rule that generated the event.                                                                                                           |
+| `{{ .Time }}`                                | The timestamp when the event occurred.                                                                                                                   |
+| `{{ index .OutputFields \"<field name>\" }}` | A map of additional optional fields emitted depending on the event. These may not be present for every event, in which case they expand to the string `<no value>`   |
+
+Go templates also support some basic methods for text manipulation which can be used to improve the clarity of alerts - see the documentation for details.
 
 ## Handlers
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ slack:
   #icon: "" # Slack icon (avatar)
   outputformat: "text" # all (default), text, fields
   minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)
-  messageformat: "Alert for rule '{{ .Rule }}' from process {{ index .OutputFields \"proc.name\" }} " # a Go template to format Slack messages, see Slack Message Formatting in the README for details
+  messageformat: "Alert : rule *{{ .Rule }}* triggered by user *{{ index .OutputFields \"user.name\" }}*" # a Go template to format Slack Text above Attachment, displayed in addition to the output from `SLACK_OUTPUTFORMAT`, see [Slack Message Formatting](#slack-message-formatting) in the README for details. If empty, no Text is displayed before Attachment.
 
 teams:
   webhookurl: "" # Teams WebhookURL (ex: https://hooks.slack.com/services/XXXX/YYYY/ZZZZ), if not empty, Teams output is enabled
@@ -167,7 +167,7 @@ The *env vars* "match" field names in *yaml file with this structure (**take car
 * **SLACK_ICON** : Slack icon (avatar)
 * **SLACK_OUTPUTFORMAT** : `all` (default), `text` (only text is displayed in Slack), `fields` (only fields are displayed in Slack)
 * **SLACK_MINIMUMPRIORITY** : minimum priority of event for using use this output, order is `emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)`
-* **SLACK_MESSAGEFORMAT** : a Go template to format Slack alert messages. This is displayed in addition to the output from `SLACK_OUTPUTFORMAT`. See [Slack Message Formatting](#slack-message-formatting) for details.
+* **SLACK_MESSAGEFORMAT** : a Go template to format Slack Text above Attachment, displayed in addition to the output from `SLACK_OUTPUTFORMAT`, see [Slack Message Formatting](#slack-message-formatting) in the README for details. If empty, no Text is displayed before Attachment.
 * **TEAMS_WEBHOOKURL** : Teams Webhook URL (ex: https://outlook.office.com/webhook/XXXXXX/IncomingWebhook/YYYYYY"), if not `empty`, Teams output is *enabled*
 * **TEAMS_ACTIVITYIMAGE** : Teams section image
 * **TEAMS_OUTPUTFORMAT** : `all` (default), `text` (only text is displayed in Teams), `facts` (only facts are displayed in Teams)

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"text/template"
 
 	"github.com/falcosecurity/falcosidekick/types"
 
@@ -27,6 +28,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Slack.Footer", "https://github.com/falcosecurity/falcosidekick")
 	v.SetDefault("Slack.Icon", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
 	v.SetDefault("Slack.OutputFormat", "all")
+	v.SetDefault("Slack.MessageFormat", "")
 	v.SetDefault("Slack.MinimumPriority", "")
 	v.SetDefault("Teams.WebhookURL", "")
 	v.SetDefault("Teams.ActivityImage", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
@@ -102,6 +104,14 @@ func getConfig() *types.Configuration {
 	if match, _ := regexp.MatchString("(?i)(emergency|alert|critical|error|warning|notice|informationnal|debug)", c.Slack.MinimumPriority); !match {
 		c.Slack.MinimumPriority = ""
 		c.Teams.MinimumPriority = ""
+	}
+
+	if c.Slack.MessageFormat != "" {
+		var err error
+		c.Slack.MessageFormatTemplate, err = template.New("slack").Parse(c.Slack.MessageFormat)
+		if err != nil {
+			log.Printf("[ERROR] : Error compiling Slack messsage template: %v", err)
+		}
 	}
 
 	return c

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -11,6 +11,7 @@ slack:
   #icon: "" # Slack icon (avatar)
   outputformat: "text" # all (default), text, fields
   minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)
+  messageformat: "Alert for rule '{{ .Rule }}' from process {{ index .OutputFields \"proc.name\" }} " # a Go template to format Slack messages, see Slack Message Formatting in the README for details
 
 teams:
   webhookurl: "" # Teams WebhookURL (ex: https://hooks.slack.com/services/XXXX/YYYY/ZZZZ), if not empty, Teams output is enabled

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -11,7 +11,7 @@ slack:
   #icon: "" # Slack icon (avatar)
   outputformat: "text" # all (default), text, fields
   minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informationnal|debug or "" (default)
-  messageformat: "Alert for rule '{{ .Rule }}' from process {{ index .OutputFields \"proc.name\" }} " # a Go template to format Slack messages, see Slack Message Formatting in the README for details
+  messageformat: "Alert : rule *{{ .Rule }}* triggered by user *{{ index .OutputFields \"user.name\" }}*" # a Go template to format Slack Text above Attachment, displayed in addition to the output from `SLACK_OUTPUTFORMAT`, see [Slack Message Formatting](#slack-message-formatting) in the README for details. If empty, no Text is displayed before Attachment.
 
 teams:
   webhookurl: "" # Teams WebhookURL (ex: https://hooks.slack.com/services/XXXX/YYYY/ZZZZ), if not empty, Teams output is enabled

--- a/deploy/helm/falcosidekick/templates/deployment.yaml
+++ b/deploy/helm/falcosidekick/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: {{ .Values.config.slack.icon | quote }}
             - name: SLACK_MINIMUMPRIORITY
               value: {{ .Values.config.slack.minimumpriority | quote }}
+            - name: SLACK_MESSAGEFORMAAT
+              value: {{ .Values.config.slack.messageformat | quote }}
             {{- end }}
             {{- if .Values.config.teams.webhookurl }}
             - name: TEAMS_WEBHOOKURL

--- a/deploy/helm/falcosidekick/values.yaml
+++ b/deploy/helm/falcosidekick/values.yaml
@@ -25,6 +25,7 @@ config:
     icon: ""
     outputformat: "all"
     minimumpriority: ""
+    messageformat: ""
 
   teams:
     webhookurl: ""

--- a/outputs/slack_test.go
+++ b/outputs/slack_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+	"text/template"
 
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
 func TestNewSlackPayload(t *testing.T) {
 	expectedOutput := slackPayload{
+		Text:     "Rule: Test rule Priority: Debug",
 		Username: "Falcosidekick",
 		IconURL:  "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick.png",
 		Attachments: []slackAttachment{
@@ -46,7 +48,9 @@ func TestNewSlackPayload(t *testing.T) {
 
 	var f types.FalcoPayload
 	json.Unmarshal([]byte(falcoTestInput), &f)
-	output := newSlackPayload(f, &types.Configuration{})
+	config := &types.Configuration{}
+	config.Slack.MessageFormatTemplate, _ = template.New("").Parse("Rule: {{ .Rule }} Priority: {{ .Priority }}")
+	output := newSlackPayload(f, config)
 	if !reflect.DeepEqual(output, expectedOutput) {
 		t.Fatalf("\nexpected payload: \n%#v\ngot: \n%#v\n", expectedOutput, output)
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"expvar"
+	"text/template"
 	"time"
 )
 
@@ -33,11 +34,13 @@ type Configuration struct {
 }
 
 type slackOutputConfig struct {
-	WebhookURL      string
-	Footer          string
-	Icon            string
-	OutputFormat    string
-	MinimumPriority string
+	WebhookURL            string
+	Footer                string
+	Icon                  string
+	OutputFormat          string
+	MinimumPriority       string
+	MessageFormat         string
+	MessageFormatTemplate *template.Template
 }
 
 type teamsOutputConfig struct {


### PR DESCRIPTION
Add a new configuration option for the Slack output, which allows users to customize the text of the Slack message in addition to the existing attachments. The current `all` and `text` options are verbose and make it hard to surface specific valuable information. Using Go templates also gives users some flexibility to do some basic string munging.