### PR TITLE
Add StatsD metrics for sidekick

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ opsgenie:
   # apikey: "" # Opsgenie API Key, if not empty, Opsgenie output is enabled
   # region: "eu" # (us|eu) region of your domain (default is 'us')
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
+
+statsd:
+  # forwarder: "" # The address for the StatsD forwarder, in the form "host:port", if not empty StatsD is enabled
+  # namespace: "falcosidekick" # A prefix for all metrics
+  # tags: "" # A comma-separated list of tags to add to all metrics
 ```
 
 Usage :
@@ -207,6 +212,9 @@ The *env vars* "match" field names in *yaml file with this structure (**take car
 * **OPSGENIE_APIKEY** : Opsgenie API Key, if not empty, Opsgenie output is enabled
 * **OPSGENIE_REGION** : "" # (us|eu) region of your domain (default is 'us')
 * **OPSGENIE_MINIMUMPRIORITY** : minimum priority of event for using this output, order is `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
+* **STATSD_FORWARDER**: The address for the StatsD forwarder, in the form "host:port", if not empty StatsD is enabled
+* **STATSD_NAMESPACE**: A prefix for all metrics
+* **STATSD_TAGS**: A comma-separated list of tags to add to all metrics
 
 #### Slack Message Formatting
 

--- a/config.go
+++ b/config.go
@@ -69,6 +69,9 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Opsgenie.Region", "us")
 	v.SetDefault("Opsgenie.APIKey", "")
 	v.SetDefault("Opsgenie.MinimumPriority", "")
+	v.SetDefault("Statsd.Forwarder", "")
+	v.SetDefault("Statsd.Namespace", "falcosidekick.")
+	v.SetDefault("Statsd.Tags", []string{})
 	v.SetDefault("Customfields", map[string]string{})
 
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -73,3 +73,8 @@ opsgenie:
   # apikey: "" # Opsgenie API Key, if not empty, Opsgenie output is enabled
   # region: "eu" # (us|eu) region of your domain
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
+
+statsd:
+  # forwarder: "" # The address for the StatsD forwarder, in the form "host:port", if not empty StatsD is enabled
+  # namespace: "falcosidekick" # A prefix for all metrics
+  # tags: "" # A comma-separated list of tags to add to all metrics

--- a/deploy/helm/falcosidekick/templates/deployment.yaml
+++ b/deploy/helm/falcosidekick/templates/deployment.yaml
@@ -193,6 +193,15 @@ spec:
             - name: OPSGENIE_MINIMUMPRIORITY
               value: {{ .Values.config.opsgenie.minimumpriority | quote }}
             {{- end }}
+            {{- if .Values.config.statsd.forwarder }}
+            - name: STATSD_FORWARDER
+              value: {{ .Values.config.statsd.forwarder | quote }}
+            - name: STATSD_NAMESPACE
+              value: {{ .Values.config.statsd.namespace | quote }}
+            - name: STATSD_TAGS
+              value: {{ .Values.config.statsd.tags | quote }}
+            {{- end }}
+
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/falcosidekick/values.yaml
+++ b/deploy/helm/falcosidekick/values.yaml
@@ -86,6 +86,11 @@ config:
     region: ""
     minimumpriority: ""
 
+  statsd:
+    forwarder: ""
+    namespace: "falcosidekick"
+    tags: ""
+
 service:
   type: ClusterIP
   port: 2801

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/falcosecurity/falcosidekick
 go 1.12
 
 require (
+	github.com/DataDog/datadog-go v2.3.0+incompatible
 	github.com/aws/aws-sdk-go v1.23.10
 	github.com/emersion/go-sasl v0.0.0-20190817083125-240c8404624e
 	github.com/emersion/go-smtp v0.11.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/datadog-go v2.3.0+incompatible h1:ypCT7tHzMUrUKjdHX6GGEsGq0yi0IYMaljwN5b6hbIc=
+github.com/DataDog/datadog-go v2.3.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/handlers.go
+++ b/handlers.go
@@ -137,5 +137,7 @@ func countMetric(metric string, value int64, tags []string) {
 	if statsdClient == nil {
 		return
 	}
-	statsdClient.Count(metric, value, tags, 1.0)
+	if err := statsdClient.Count(metric, value, tags, 1); err != nil {
+		log.Printf("[ERROR] : Unable to send metric to StatsD - %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/falcosecurity/falcosidekick/outputs"
 	"github.com/falcosecurity/falcosidekick/types"
 )
@@ -14,15 +15,26 @@ import (
 var slackClient, teamsClient, datadogClient, alertmanagerClient, elasticsearchClient, influxdbClient, lokiClient, natsClient, awsClient, smtpClient, opsgenieClient *outputs.Client
 var config *types.Configuration
 var stats *types.Statistics
+var statsdClient *statsd.Client
 
 func init() {
 	config = getConfig()
 	stats = getInitStats()
 
+	if config.Statsd.Forwarder != "" {
+		var err error
+		statsdClient, err = statsd.New(config.Statsd.Forwarder, statsd.WithNamespace(config.Statsd.Namespace), statsd.WithTags(config.Statsd.Tags))
+		if err != nil {
+			log.Printf("[EROR]  : Can't configure StatsD client for %v - %v", config.Statsd.Forwarder, err)
+		} else {
+			log.Printf("[INFO]  : Emitting StatsD metrics to %v", config.Statsd.Forwarder)
+		}
+	}
+
 	enabledOutputsText := "[INFO]  : Enabled Outputs : "
 	if config.Slack.WebhookURL != "" {
 		var err error
-		slackClient, err = outputs.NewClient("Slack", config.Slack.WebhookURL, config, stats)
+		slackClient, err = outputs.NewClient("Slack", config.Slack.WebhookURL, config, stats, statsdClient)
 		if err != nil {
 			config.Slack.WebhookURL = ""
 		} else {
@@ -31,7 +43,7 @@ func init() {
 	}
 	if config.Teams.WebhookURL != "" {
 		var err error
-		teamsClient, err = outputs.NewClient("Teams", config.Teams.WebhookURL, config, stats)
+		teamsClient, err = outputs.NewClient("Teams", config.Teams.WebhookURL, config, stats, statsdClient)
 		if err != nil {
 			config.Teams.WebhookURL = ""
 		} else {
@@ -40,7 +52,7 @@ func init() {
 	}
 	if config.Datadog.APIKey != "" {
 		var err error
-		datadogClient, err = outputs.NewClient("Datadog", outputs.DatadogURL+"?apikey="+config.Datadog.APIKey, config, stats)
+		datadogClient, err = outputs.NewClient("Datadog", outputs.DatadogURL+"?apikey="+config.Datadog.APIKey, config, stats, statsdClient)
 		if err != nil {
 			config.Datadog.APIKey = ""
 		} else {
@@ -49,7 +61,7 @@ func init() {
 	}
 	if config.Alertmanager.HostPort != "" {
 		var err error
-		alertmanagerClient, err = outputs.NewClient("AlertManager", config.Alertmanager.HostPort+outputs.AlertmanagerURI, config, stats)
+		alertmanagerClient, err = outputs.NewClient("AlertManager", config.Alertmanager.HostPort+outputs.AlertmanagerURI, config, stats, statsdClient)
 		if err != nil {
 			config.Alertmanager.HostPort = ""
 		} else {
@@ -58,7 +70,7 @@ func init() {
 	}
 	if config.Elasticsearch.HostPort != "" {
 		var err error
-		elasticsearchClient, err = outputs.NewClient("Elasticsearch", config.Elasticsearch.HostPort+"/"+config.Elasticsearch.Index+"/"+config.Elasticsearch.Type, config, stats)
+		elasticsearchClient, err = outputs.NewClient("Elasticsearch", config.Elasticsearch.HostPort+"/"+config.Elasticsearch.Index+"/"+config.Elasticsearch.Type, config, stats, statsdClient)
 		if err != nil {
 			config.Elasticsearch.HostPort = ""
 		} else {
@@ -67,7 +79,7 @@ func init() {
 	}
 	if config.Loki.HostPort != "" {
 		var err error
-		lokiClient, err = outputs.NewClient("Loki", config.Loki.HostPort+"/api/prom/push", config, stats)
+		lokiClient, err = outputs.NewClient("Loki", config.Loki.HostPort+"/api/prom/push", config, stats, statsdClient)
 		if err != nil {
 			config.Loki.HostPort = ""
 		} else {
@@ -76,7 +88,7 @@ func init() {
 	}
 	if config.Nats.HostPort != "" {
 		var err error
-		natsClient, err = outputs.NewClient("NATS", config.Nats.HostPort, config, stats)
+		natsClient, err = outputs.NewClient("NATS", config.Nats.HostPort, config, stats, statsdClient)
 		if err != nil {
 			config.Nats.HostPort = ""
 		} else {
@@ -89,7 +101,7 @@ func init() {
 			credentials = "&u=" + config.Influxdb.User + "&p=" + config.Influxdb.Password
 		}
 		var err error
-		influxdbClient, err = outputs.NewClient("Influxdb", config.Influxdb.HostPort+"/write?db="+config.Influxdb.Database+credentials, config, stats)
+		influxdbClient, err = outputs.NewClient("Influxdb", config.Influxdb.HostPort+"/write?db="+config.Influxdb.Database+credentials, config, stats, statsdClient)
 		if err != nil {
 			config.Influxdb.HostPort = ""
 		} else {
@@ -98,7 +110,7 @@ func init() {
 	}
 	if config.AWS.Lambda.FunctionName != "" || config.AWS.SQS.URL != "" {
 		var err error
-		awsClient, err = outputs.NewAWSClient("AWS", config, stats)
+		awsClient, err = outputs.NewAWSClient("AWS", config, stats, statsdClient)
 		if err != nil {
 			config.AWS.AccessKeyID = ""
 			config.AWS.SecretAccessKey = ""
@@ -116,7 +128,7 @@ func init() {
 	}
 	if config.SMTP.HostPort != "" && config.SMTP.From != "" && config.SMTP.To != "" {
 		var err error
-		smtpClient, err = outputs.NewSMTPClient("SMTP", config, stats)
+		smtpClient, err = outputs.NewSMTPClient("SMTP", config, stats, statsdClient)
 		if err != nil {
 			config.SMTP.HostPort = ""
 		} else {
@@ -129,7 +141,7 @@ func init() {
 		if strings.ToLower(config.Opsgenie.Region) == "eu" {
 			url = "https://api.eu.opsgenie.com/v2/alerts"
 		}
-		opsgenieClient, err = outputs.NewClient("Opsgenie", url, config, stats)
+		opsgenieClient, err = outputs.NewClient("Opsgenie", url, config, stats, statsdClient)
 		if err != nil {
 			config.Opsgenie.APIKey = ""
 		} else {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func init() {
 		var err error
 		statsdClient, err = statsd.New(config.Statsd.Forwarder, statsd.WithNamespace(config.Statsd.Namespace), statsd.WithTags(config.Statsd.Tags))
 		if err != nil {
-			log.Printf("[EROR]  : Can't configure StatsD client for %v - %v", config.Statsd.Forwarder, err)
+			log.Printf("[ERROR]  : Can't configure StatsD client for %v - %v", config.Statsd.Forwarder, err)
 		} else {
 			log.Printf("[INFO]  : Emitting StatsD metrics to %v", config.Statsd.Forwarder)
 		}

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/falcosecurity/falcosidekick/types"
 )
@@ -37,15 +38,16 @@ var ErrClientCreation = errors.New("Client creation Error")
 
 // Client communicates with the different API.
 type Client struct {
-	OutputType  string
-	EndpointURL *url.URL
-	Config      *types.Configuration
-	Stats       *types.Statistics
-	AWSSession  *session.Session
+	OutputType   string
+	EndpointURL  *url.URL
+	Config       *types.Configuration
+	Stats        *types.Statistics
+	AWSSession   *session.Session
+	StatsdClient *statsd.Client
 }
 
 // NewClient returns a new output.Client for accessing the different API.
-func NewClient(outputType string, defaultEndpointURL string, config *types.Configuration, stats *types.Statistics) (*Client, error) {
+func NewClient(outputType string, defaultEndpointURL string, config *types.Configuration, stats *types.Statistics, statsdClient *statsd.Client) (*Client, error) {
 	reg := regexp.MustCompile(`(http|nats)(s?)://.*`)
 	if !reg.MatchString(defaultEndpointURL) {
 		log.Printf("[ERROR] : %v - %v\n", outputType, "Bad Endpoint")
@@ -60,7 +62,7 @@ func NewClient(outputType string, defaultEndpointURL string, config *types.Confi
 		log.Printf("[ERROR] : %v - %v\n", outputType, err.Error())
 		return nil, ErrClientCreation
 	}
-	return &Client{OutputType: outputType, EndpointURL: endpointURL, Config: config, Stats: stats}, nil
+	return &Client{OutputType: outputType, EndpointURL: endpointURL, Config: config, Stats: stats, StatsdClient: statsdClient}, nil
 }
 
 // Post sends event (payload) to Output.
@@ -107,6 +109,7 @@ func (c *Client) Post(payload interface{}) error {
 	}
 	defer resp.Body.Close()
 
+	c.CountMetric("outputs", 1, []string{"output:" + c.OutputType, "status:" + http.StatusText(resp.StatusCode)})
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: //200, 201, 202, 204
 		log.Printf("[INFO]  : %v - Post OK (%v)\n", c.OutputType, resp.StatusCode)
@@ -133,4 +136,13 @@ func (c *Client) Post(payload interface{}) error {
 		log.Printf("[ERROR] : %v - Unexpected Response  (%v)\n", c.OutputType, resp.StatusCode)
 		return errors.New(resp.Status)
 	}
+}
+
+func (c *Client) CountMetric(name string, value int64, tags []string) {
+	// No-op if statsd metrics aren't configured
+	if c.StatsdClient == nil {
+		return
+	}
+
+	c.StatsdClient.Count(name, value, tags, 1)
 }

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -144,5 +144,7 @@ func (c *Client) CountMetric(name string, value int64, tags []string) {
 		return
 	}
 
-	c.StatsdClient.Count(name, value, tags, 1)
+	if err := c.StatsdClient.Count(name, value, tags, 1); err != nil {
+		log.Printf("[ERROR] : Unable to send metric to StatsD - %v", err)
+	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -30,6 +30,7 @@ type Configuration struct {
 	AWS           awsOutputConfig
 	SMTP          smtpOutputConfig
 	Opsgenie      opsgenieOutputConfig
+	Statsd        statsdConfig
 	Customfields  map[string]string
 }
 
@@ -120,6 +121,12 @@ type opsgenieOutputConfig struct {
 	Region          string
 	APIKey          string
 	MinimumPriority string
+}
+
+type statsdConfig struct {
+	Forwarder string
+	Namespace string
+	Tags      []string
 }
 
 // Statistics is a struct to store stastics


### PR DESCRIPTION
Adds StatsD metrics using the datadog-go client, similar to the current expvars:

`falcosidekick.incoming` - total requests received from falco
`falcosidekick.rejected` - invalid/malformed requests
`falcosidekick.accepted` - events received and parsed
`falcosidekick.output` - events forwarded, tagged by output and status code

This allows some simple dashboarding and monitoring to ensure sidekick is receiving events and those events are being successfully forwarded to various outputs. Tested with dogstatsd as the forwarder, but this should work with other StatsD forwarders as well.