### PR TITLE
Bug: Fix Slack Message ENV on Deploy

### DIFF
--- a/deploy/helm/falcosidekick/templates/deployment.yaml
+++ b/deploy/helm/falcosidekick/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               value: {{ .Values.config.slack.icon | quote }}
             - name: SLACK_MINIMUMPRIORITY
               value: {{ .Values.config.slack.minimumpriority | quote }}
-            - name: SLACK_MESSAGEFORMAAT
+            - name: SLACK_MESSAGEFORMAT
               value: {{ .Values.config.slack.messageformat | quote }}
             {{- end }}
             {{- if .Values.config.teams.webhookurl }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
Helm ENV typo fix, allows for passing the Slack Message Format options.