### PR TITLE
Fix datadog api_key query parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func init() {
 	}
 	if config.Datadog.APIKey != "" {
 		var err error
-		datadogClient, err = outputs.NewClient("Datadog", outputs.DatadogURL+"?apikey="+config.Datadog.APIKey, config, stats, statsdClient, dogstatsdClient)
+		datadogClient, err = outputs.NewClient("Datadog", outputs.DatadogURL+"?api_key="+config.Datadog.APIKey, config, stats, statsdClient, dogstatsdClient)
 		if err != nil {
 			config.Datadog.APIKey = ""
 		} else {


### PR DESCRIPTION
According to the documentation at https://docs.datadoghq.com/api/#post-an-event
the query parameter is named `api_key`. Also tired curling a request to
datadog and got 403 just like when running falco sidekick.