### PR TITLE
Add new config Datadog.Host for using the Datadog EU site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ falcosidekick
 config.yaml
 .env
 .vscode
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 2.12.3 - 2020-04-21
+#### Enhancement
+- Allow using Datadog EU site by specifying new configuration *datadog.host*.
+
 ## 2.12.2 - 2020-04-21
 #### Fix
 - Typo in query to Datadog ([PR#58](https://github.com/falcosecurity/falcosidekick/pull/58) thanks to [@DrPhil](https://github.com/DrPhil))

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ teams:
   minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 datadog:
-  #apikey: ""  # Datadog API Key, if not empty, Datadog output is enabled
+  # apikey: "" # Datadog API Key, if not empty, Datadog output is enabled
+  # host: "" # Datadog host. Override if you are on the Datadog EU site. Defaults to american site with "https://api.datadoghq.com"
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 alertmanager:
@@ -200,6 +201,7 @@ The *env vars* "match" field names in *yaml file with this structure (**take car
 * **TEAMS_OUTPUTFORMAT** : `all` (default), `text` (only text is displayed in Teams), `facts` (only facts are displayed in Teams)
 * **TEAMS_MINIMUMPRIORITY** : minimum priority of event for using use this output, order is `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
 * **DATADOG_APIKEY** : Datadog API Key, if not `empty`, Datadog output is *enabled*
+* **DATADOG_HOST** : Datadog host. Override if you are on the Datadog EU site. Defaults to american site with "https://api.datadoghq.com"
 * **DATADOG_MINIMUMPRIORITY** : minimum priority of event for using this output, order is `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
 * **ALERTMANAGER_HOSTPORT** : AlertManager http://host:port, if not `empty`, AlertManager is *enabled*
 * **ALERTMANAGER_MINIMUMPRIORITY** : minimum priority of event for using this output, order is `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
@@ -245,7 +247,7 @@ The *env vars* "match" field names in *yaml file with this structure (**take car
 #### Slack Message Formatting
 
 The `SLACK_MESSAGEFORMAT` environment variable and `slack.messageformat` YAML value accept a [Go template](https://golang.org/pkg/text/template/) which can be used to format the text of a slack alert. These templates are evaluated on the JSON data from each Falco event - the following fields are available:
-                                                                                                                   
+
 | Template Syntax                              | Description      |
 |----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `{{ .Output }}`                              | A formatted string from Falco describing the event.                                                                                                      |

--- a/config.go
+++ b/config.go
@@ -35,6 +35,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Teams.OutputFormat", "all")
 	v.SetDefault("Teams.MinimumPriority", "")
 	v.SetDefault("Datadog.APIKey", "")
+	v.SetDefault("Datadog.Host", "https://api.datadoghq.com")
 	v.SetDefault("Datadog.MinimumPriority", "")
 	v.SetDefault("Alertmanager.HostPort", "")
 	v.SetDefault("Alertmanager.MinimumPriority", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -20,7 +20,8 @@ teams:
   minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 datadog:
-  #apikey: ""  # Datadog API Key, if not empty, Datadog output is enabled
+  # apikey: "" # Datadog API Key, if not empty, Datadog output is enabled
+  # host: "" # Datadog host. Override if you are on the Datadog EU site. Defaults to american site with "https://api.datadoghq.com"
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 alertmanager:
@@ -32,7 +33,7 @@ elasticsearch:
   # index: "falco" # index (default: falco)
   # type: "event"
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-  # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none 
+  # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
 
 influxdb:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Influxdb output is enabled
@@ -67,11 +68,6 @@ smtp:
   # from: "" # Sender address (mandatory if SMTP output is enabled)
   # to: "" # comma-separated list of Recipident addresses, can't be empty (mandatory if SMTP output is enabled)
   # outputformat: "" # html (default), text
-  # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-
-opsgenie:
-  # apikey: "" # Opsgenie API Key, if not empty, Opsgenie output is enabled
-  # region: "eu" # (us|eu) region of your domain
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 statsd:

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func init() {
 	}
 	if config.Datadog.APIKey != "" {
 		var err error
-		datadogClient, err = outputs.NewClient("Datadog", outputs.DatadogURL+"?api_key="+config.Datadog.APIKey, config, stats, statsdClient, dogstatsdClient)
+		datadogClient, err = outputs.NewClient("Datadog", config.Datadog.Host+outputs.DatadogPath+"?api_key="+config.Datadog.APIKey, config, stats, statsdClient, dogstatsdClient)
 		if err != nil {
 			config.Datadog.APIKey = ""
 		} else {

--- a/outputs/datadog.go
+++ b/outputs/datadog.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	// DatadogURL is default URL of Datadog's API
-	DatadogURL string = "https://api.datadoghq.com/api/v1/events"
+	// DatadogPath is the path of Datadog's event API
+	DatadogPath string = "/api/v1/events"
 )
 
 type datadogPayload struct {

--- a/types/types.go
+++ b/types/types.go
@@ -55,6 +55,7 @@ type teamsOutputConfig struct {
 
 type datadogOutputConfig struct {
 	APIKey          string
+	Host            string
 	MinimumPriority string
 }
 


### PR DESCRIPTION
Users of the Datadog EU site should be using the another host
for their API requests, see https://docs.datadoghq.com/api/#authentication
The default value of Datadog.Host is kept as the american site, so
no changes are needed for existing (american) Datadog users.

This is my first time writing Go, so feel free to edit anything that
looks out of place.

Tested locally with both env and config file