### PR TITLE
update(.github): remove release-note block from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,7 @@
 
 1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
 2. Please label this pull request according to what type of issue you are addressing.
-3. . Please add a release note!
-4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
+3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
 -->
 
 **What type of PR is this?**
@@ -58,16 +57,4 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**Does this PR introduce a user-facing change?**:
 
-<!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
-If the PR requires additional action from users switching to the new release, prepend the string "action required:".
-For example, `action required: change the API interface of the rule engine`.
--->
-
-```release-note
-
-```


### PR DESCRIPTION

**What type of PR is this?**


/kind cleanup



/kind documentation



**Any specific area of the project related to this PR?**

NONE



**What this PR does / why we need it**:

As per @Issif request, it removes the `release-note` block from the PR template.

**Which issue(s) this PR fixes**:

Refs https://github.com/falcosecurity/test-infra/issues/149




