### PR TITLE
Add imagePullSecretes to the Helm chart

### DIFF
--- a/deploy/helm/falcosidekick/Chart.yaml
+++ b/deploy/helm/falcosidekick/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "2.14.0"
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick.png
 name: falcosidekick
-version: 0.1.20
+version: 0.1.21
 maintainers:
   - name: Issif

--- a/deploy/helm/falcosidekick/templates/deployment.yaml
+++ b/deploy/helm/falcosidekick/templates/deployment.yaml
@@ -22,6 +22,12 @@ spec:
         aadpodidbinding: {{ include "falcosidekick.fullname" . }}
         {{- end }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "falcosidekick.fullname" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/deploy/helm/falcosidekick/values.yaml
+++ b/deploy/helm/falcosidekick/values.yaml
@@ -8,6 +8,10 @@ image:
   repository: falcosecurity/falcosidekick
   tag: 2.13.0
   pullPolicy: IfNotPresent
+  
+# One or more secrets to be used when pulling images
+imagePullSecrets: []
+# - registrySecretName
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Signed-off-by: Armin <armin@coralic.nl>
**What type of PR is this?**

/kind feature
**Any specific area of the project related to this PR?**

/area helm

**What this PR does / why we need it**:

Adding the imagePullSecrets to the Helm deployments to allow authenticated Docker registries.


