### PR TITLE
cardinality matters, n_events labels on alertmanager

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -1,6 +1,7 @@
 package outputs
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/falcosecurity/falcosidekick/types"
@@ -22,6 +23,43 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPaylo
 	amPayload.Annotations = make(map[string]string)
 
 	for i, j := range falcopayload.OutputFields {
+		if strings.HasPrefix(i, "n_evts") {
+			// avoid delta evts as label
+			continue
+		}
+		// strip cardinalities of syscall drops
+		if strings.HasPrefix(i, "n_drop") {
+			d, err := strconv.ParseInt(j.(string), 10, 64)
+			if err == nil {
+				var jj string
+				switch d {
+				case d == 0:
+					jj = "0"
+					falcopayload.Priority = "warning"
+				case d < 10 {
+					jj = "<10"
+					falcopayload.Priority = "warning"
+				case d > 10000:
+					jj = ">10000"
+					falcopayload.Priority = "critical"
+				case d > 1000 {
+					jj = ">1000"
+					falcopayload.Priority = "critical"
+				case d > 100 {
+					jj = ">100"
+					falcopayload.Priority = "critical"
+				case d > 10 {
+					jj = ">10"
+					falcopayload.Priority = "warning"
+				default:
+					jj = j.(string)
+					falcopayload.Priority = "critical"
+				}
+
+				amPayload.Labels[i] = jj
+			}
+			continue
+		}
 		switch j.(type) {
 		case string:
 			//AlertManger doesn't support dots in a label name


### PR DESCRIPTION

**What type of PR is this?**

with n_events* metrics, we send actual values as labels to alertmanager -> which increases cardinality and makes impossible to aggregate alerts later. 

- this PR drpps n_events (which is just delta)
- and replaces actuall values with string representation how many events in range was dropped (possibly could be done better with integer values) -> however the assumtion here is that it shall not happen at all.