### PR TITLE
Prefix falco alerts send to Alertmanager

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/falcosecurity/falcosidekick/types"
+	"github.com/iancoleman/strcase"
 )
 
 const (
@@ -35,6 +36,9 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPaylo
 
 	amPayload.Annotations["info"] = falcopayload.Output
 	amPayload.Annotations["summary"] = falcopayload.Rule
+
+	// Prefix alertname
+	amPayload.Labels["alertname"] = "Falco" + strcase.ToCamel(string(falcopayload.Rule))
 
 	var a []alertmanagerPayload
 


### PR DESCRIPTION


**What type of PR is this?**
/kind feature

I find better to prefix all alerts from the source with it's name, rather than use "source" label. 