### PR TITLE
falco helm Chart variables have moved from underscores to CamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ helm install --name falcosidekick .
 Add this (adapted to your environment) in your *falco.yaml* :
 
 ```bash
-json_output: true
-json_include_output_property: true
-http_output:
+jsonOutput: true
+jsonIncludeOutputProperty: true
+httpOutput:
   enabled: true
   url: "http://localhost:2801/"
 ```
@@ -71,11 +71,11 @@ http_output:
 or
 
 ```bash
-json_output: true
-json_include_output_property: true
-program_output:
+jsonOutput: true
+jsonIncludeOutputProperty: true
+programOutput:
   enabled: true
-  keep_alive: false
+  keepAlive: false
   program: "curl -d @- localhost:2801/"
 ```
 


### PR DESCRIPTION
Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>

**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area helm

**What this PR does / why we need it**:

The varibales in the faclo helm Chart have changed, e.g.:
https://github.com/falcosecurity/charts/blob/master/falco/values.yaml#L236

Copy&Paste of the example falco config didn't work.
