### PR TITLE
Replace extensions with policy because of deprecation

### DIFF
--- a/deploy/helm/falcosidekick/Chart.yaml
+++ b/deploy/helm/falcosidekick/Chart.yaml
@@ -3,6 +3,6 @@ appVersion: "2.14.0"
 description: A simple daemon to help you with falco's outputs
 icon: https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick.png
 name: falcosidekick
-version: 0.1.20
+version: 0.1.21
 maintainers:
   - name: Issif

--- a/deploy/helm/falcosidekick/templates/clusterrole.yaml
+++ b/deploy/helm/falcosidekick/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     resourceNames:


### PR DESCRIPTION
Deprecation Info:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

The current docs also show the policy apiGroup:
https://kubernetes.io/docs/concepts/policy/pod-security-policy/#via-rbac

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area helm

**What this PR does / why we need it**:
