### PR TITLE
Fix ENV DISCORD_WEBHOOKURL being set when SLACK_WEBHOOKURL is present

### DIFF
--- a/deploy/helm/falcosidekick/templates/deployment.yaml
+++ b/deploy/helm/falcosidekick/templates/deployment.yaml
@@ -265,7 +265,7 @@ spec:
             - name: AZURE_EVENTHUB_MINIMUMPRIORITY
               value: {{ .Values.config.azure.eventHub.minimumpriority | quote }}
             {{- end }}
-            {{- if .Values.config.slack.webhookurl }}
+            {{- if .Values.config.discord.webhookurl }}
             - name: DISCORD_WEBHOOKURL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area helm

**What this PR does / why we need it**:

When creating a Slack only deployment, the deployment would incorrectly try to set the environmebnt variable DISCORD_WEBHOOKURL based on the deployed secrets (which in this case aren't present).

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

