### PR TITLE
fix nil pointer when gcp config is incorrect + normalize labels of stats

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -204,7 +204,7 @@ func forwardEvent(falcopayload types.FalcoPayload) {
 		go azureClient.EventHubPost(falcopayload)
 	}
 
-	if config.GCP.PubSub.Topic != "" && (priorityMap[strings.ToLower(falcopayload.Priority)] >= priorityMap[strings.ToLower(config.GCP.PubSub.MinimumPriority)] || falcopayload.Rule == TestRule) {
+	if config.GCP.PubSub.ProjectID != "" && config.GCP.PubSub.Topic != "" && (priorityMap[strings.ToLower(falcopayload.Priority)] >= priorityMap[strings.ToLower(config.GCP.PubSub.MinimumPriority)] || falcopayload.Rule == TestRule) {
 		go gcpClient.GCPPublishTopic(falcopayload)
 	}
 

--- a/main.go
+++ b/main.go
@@ -274,7 +274,8 @@ func init() {
 		var err error
 		gcpClient, err = outputs.NewGCPClient(config, stats, promStats, statsdClient, dogstatsdClient)
 		if err != nil {
-			config.GCP.Credentials = ""
+			config.GCP.PubSub.ProjectID = ""
+			config.GCP.PubSub.Topic = ""
 		} else {
 			enabledOutputsText += "GCPPubSub "
 		}

--- a/outputs/constants.go
+++ b/outputs/constants.go
@@ -13,9 +13,11 @@ const (
 	Info          string = "info"
 	None          string = "none"
 
-	All    string = "all"
-	Fields string = "fields"
-	Total  string = "total"
+	All      string = "all"
+	Fields   string = "fields"
+	Total    string = "total"
+	Rejected string = "rejected"
+	Accepted string = "accepted"
 
 	Rule     string = "rule"
 	Priority string = "priority"

--- a/stats.go
+++ b/stats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/falcosecurity/falcosidekick/outputs"
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
@@ -46,31 +47,31 @@ func getInitStats() *types.Statistics {
 		GoogleChat:        getOutputNewMap("googlechat"),
 		Kafka:             getOutputNewMap("kafka"),
 	}
-	stats.Falco.Add("emergency", 0)
-	stats.Falco.Add("alert", 0)
-	stats.Falco.Add("critical", 0)
-	stats.Falco.Add("error", 0)
-	stats.Falco.Add("warning", 0)
-	stats.Falco.Add("notice", 0)
-	stats.Falco.Add("informational", 0)
-	stats.Falco.Add("debug", 0)
-	stats.Falco.Add("unknown", 0)
+	stats.Falco.Add(outputs.Emergency, 0)
+	stats.Falco.Add(outputs.Alert, 0)
+	stats.Falco.Add(outputs.Critical, 0)
+	stats.Falco.Add(outputs.Error, 0)
+	stats.Falco.Add(outputs.Warning, 0)
+	stats.Falco.Add(outputs.Notice, 0)
+	stats.Falco.Add(outputs.Informational, 0)
+	stats.Falco.Add(outputs.Debug, 0)
+	stats.Falco.Add(outputs.None, 0)
 
 	return stats
 }
 
 func getInputNewMap(s string) *expvar.Map {
 	e := expvar.NewMap("inputs." + s)
-	e.Add("total", 0)
-	e.Add("rejected", 0)
-	e.Add("accepted", 0)
+	e.Add(outputs.Total, 0)
+	e.Add(outputs.Rejected, 0)
+	e.Add(outputs.Accepted, 0)
 	return e
 }
 
 func getOutputNewMap(s string) *expvar.Map {
 	e := expvar.NewMap("outputs." + s)
-	e.Add("total", 0)
-	e.Add("error", 0)
-	e.Add("ok", 0)
+	e.Add(outputs.Total, 0)
+	e.Add(outputs.Error, 0)
+	e.Add(outputs.OK, 0)
 	return e
 }


### PR DESCRIPTION
Signed-off-by: Issif <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area config

> /area outputs

> /area tests

> /area helm

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When `GCP` configuration was incorrect, the output was not correctly disabled, it triggered a `nil pointer dereference` error at first event and a crash of `falcosidekick`.

```
2020/11/29 19:48:44 [ERROR] : GCP - Error while base64-decoding GCP Credentials
2020/11/29 19:48:44 [INFO]  : Enabled Outputs : 
2020/11/29 19:48:44 [INFO]  : Falco Sidekick is up and listening on port 2801
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x18ec417]

goroutine 26 [running]:
github.com/falcosecurity/falcosidekick/outputs.(*Client).GCPPublishTopic(0x0, 0xc000128000, 0x21, 0xc000126858, 0x5, 0xc000126880, 0x9, 0x0, 0xed755e410, 0x0, ...)
        /Users/thomas/Src/github/falcosidekick/outputs/gcp.go:52 +0x37
created by main.forwardEvent
        /Users/thomas/Src/github/falcosidekick/handlers.go:183 +0x2c5
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

N/A

Fixes #

**Special notes for your reviewer**:

thanks to @leogr who spotted that bug
