### PR TITLE
ci: when merging to the main branch push the latest tag image to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,19 @@ jobs:
     - setup_remote_docker
     - run: make build-image
 
+  build-push-main:
+    executor:
+      name: default
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run: make build-image
+    - run:
+        command: |
+          echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
+          docker push falcosecurity/falcosidekick:latest
+
+
 workflows:
   main:
     jobs:
@@ -45,4 +58,11 @@ workflows:
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*(-.*)*/
-
+      - build-push-main:
+          context: falco
+          requires:
+            - test
+            - lint
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
When we merge to the main branch we can push the tag `latest` of `falcosidekick` image to docker hub, for people that want to live in the edge 😄 

This is not for release, just update the `lastest` tag image.

The release thing will be in a followup pr

/assign @leogr @Issif 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


