### PR TITLE
Change `/ping` endpoint to `/healthz`

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ Go templates also support some basic methods for text manipulation which can be 
 Different URI (handlers) are available :
 
 * `/` : main and default handler, your falco config must be configured to use it
-* `/ping` : you will get a  `pong` as answer, useful to test if falcosidekick is running and its port is opened (for healthcheck purpose for example)
+* `/ping` : you will get a  `pong` as answer, useful to test if falcosidekick is running and its port is opened (for healthcheck purpose for example). This endpoint is deprecated and it will be removed in `3.0.0`.
+* `/healthz`: you will get a HTTP status code `200` response as answer, useful to test if falcosidekick is running and its port is opened (for healthcheck or purpose for example)
 * `/test` : (for debug only) send a test event to all enabled outputs.
 * `/debug/vars` : get statistics from daemon (in JSON format), it uses classic `expvar` package and some custom values are added
 * `/metrics` : prometheus endpoint, for scraping metrics about events and `falcosidekick`

--- a/handlers.go
+++ b/handlers.go
@@ -68,8 +68,8 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
 	forwardEvent(falcopayload)
 }
 
-// pingHandler is a simple handler to test if daemon is UP.
-func pingHandler(w http.ResponseWriter, r *http.Request) {
+// healthHandler is a simple handler to test if daemon is UP.
+func healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("pong\n"))
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -68,9 +68,14 @@ func mainHandler(w http.ResponseWriter, r *http.Request) {
 	forwardEvent(falcopayload)
 }
 
+// pingHandler is a simple handler to test if daemon is UP.
+func pingHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("pong\n"))
+}
+
 // healthHandler is a simple handler to test if daemon is UP.
 func healthHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write([]byte("pong\n"))
+	w.WriteHeader(http.StatusOK)
 }
 
 // testHandler sends a test event to all enabled outputs.

--- a/handlers.go
+++ b/handlers.go
@@ -75,7 +75,8 @@ func pingHandler(w http.ResponseWriter, r *http.Request) {
 
 // healthHandler is a simple handler to test if daemon is UP.
 func healthHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
+	w.Header().Add("Content-Type", "application/json")
+	w.Write([]byte("{\"status\": \"ok\"}"))
 }
 
 // testHandler sends a test event to all enabled outputs.

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func init() {
 
 func main() {
 	http.HandleFunc("/", mainHandler)
-	http.HandleFunc("/ping", pingHandler)
+	http.HandleFunc("/healthz", healthHandler)
 	http.HandleFunc("/test", testHandler)
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/main.go
+++ b/main.go
@@ -320,6 +320,7 @@ func init() {
 
 func main() {
 	http.HandleFunc("/", mainHandler)
+	http.HandleFunc("/ping", pingHandler)
 	http.HandleFunc("/healthz", healthHandler)
 	http.HandleFunc("/test", testHandler)
 	http.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Unify the health check endpoint with cloud native conversion. 
This endpoint is used for health checking. See the chart implementation too https://github.com/falcosecurity/charts/blob/40e45b1f1ef2f79787f1d35b5ba565b880f626de/falcosidekick/templates/deployment.yaml#L47-L58

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Many projects in CNCF expose `/healthz` endpoint as health check endpoint. I picked some for example: 

* [healthz, ArgoCD](https://github.com/argoproj/argo-cd/blob/85ea4c445e1c66b710a490c2375138d7009d22a4/util/healthz/healthz_test.go)
* [healthz, Almost all Kubernetes Components](https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/staging/src/k8s.io/apiserver/pkg/server/healthz.go)
* [GoogleCloudPlatform/continuous-deployment-on-kubernetes ](https://github.com/GoogleCloudPlatform/continuous-deployment-on-kubernetes)
* etc

As this project is one of cloud native projects, I think it's better to unify with the cloud native convention.
 