### PR TITLE
Prefer to use kubernetes.Interface.

### DIFF
--- a/outputs/client.go
+++ b/outputs/client.go
@@ -58,7 +58,7 @@ type Client struct {
 	GCPTopicClient   *pubsub.Topic
 	KafkaProducer    *kafka.Conn
 	PagerdutyClient  *pagerduty.Client
-	KubernetesClient *kubernetes.Clientset
+	KubernetesClient kubernetes.Interface
 }
 
 // NewClient returns a new output.Client for accessing the different API.


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

In using kubernetes clients, you really should not use the Clientset struct, instead use the Interface.

