### PR TITLE
Include numeric values from falco payloads in alertmanager alerts

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -73,7 +73,10 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	var falcopayload types.FalcoPayload
 
-	err := json.NewDecoder(payload).Decode(&falcopayload)
+	d := json.NewDecoder(payload)
+	d.UseNumber()
+
+	err := d.Decode(&falcopayload)
 	if err != nil {
 		return types.FalcoPayload{}, err
 	}

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -1,6 +1,7 @@
 package outputs
 
 import (
+	"encoding/json"
 	"log"
 	"strconv"
 	"strings"
@@ -22,6 +23,7 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPaylo
 	var amPayload alertmanagerPayload
 	amPayload.Labels = make(map[string]string)
 	amPayload.Annotations = make(map[string]string)
+	replacer := strings.NewReplacer(".", "_", "[", "_", "]", "")
 
 	for i, j := range falcopayload.OutputFields {
 		if strings.HasPrefix(i, "n_evts") {
@@ -64,8 +66,9 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPaylo
 		switch v := j.(type) {
 		case string:
 			//AlertManger unsupported chars in a label name
-			replacer := strings.NewReplacer(".", "_", "[", "_", "]", "")
 			amPayload.Labels[replacer.Replace(i)] = v
+		case json.Number:
+			amPayload.Labels[replacer.Replace(i)] = v.String()
 		default:
 			continue
 		}

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -2,18 +2,21 @@ package outputs
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/falcosecurity/falcosidekick/types"
-
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewAlertmanagerPayload(t *testing.T) {
-	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","rule":"Test rule","source":"falco"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
+func TestNewAlertmanagerPayloadO(t *testing.T) {
+	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","proc_tty":"1234","rule":"Test rule","source":"falco"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
 
 	var f types.FalcoPayload
-	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+	d := json.NewDecoder(strings.NewReader(falcoTestInput))
+	d.UseNumber()
+	err := d.Decode(&f) //have to decode it the way newFalcoPayload does
+	require.Nil(t, err)
 	s, err := json.Marshal(newAlertmanagerPayload(f))
 	require.Nil(t, err)
 


### PR DESCRIPTION
Use the json UseNumber() option to not decode numbers as float64 then
when creating the am payload can just call .String on the json.Number
this means that ints don't get unnecessary precision and floats
aren't cut off short.

resolves #176

/kind feature
/area outputs

