### PR TITLE
set Webui.URL default address empty

### DIFF
--- a/config.go
+++ b/config.go
@@ -140,7 +140,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Kubeless.Port", 8080)
 	v.SetDefault("Kubeless.Kubeconfig", "")
 	v.SetDefault("Kubeless.MinimumPriority", "")
-	v.SetDefault("Webui.URL", "http://localhost:2802")
+	v.SetDefault("Webui.URL", "")
 
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()


### PR DESCRIPTION
Signed-off-by: Vyacheslav Mitrofanov <unflag@ymail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area config

**What this PR does / why we need it**:
Simply removes default "http://localhost:2802" value for Webui.URL config parameter

**Which issue(s) this PR fixes**:
Currently webui output starts even if there is no such intention and begins to fill logs with errors:
```
2021/02/09 16:24:49 [ERROR] : WebUI - Post "http://localhost:2802": dial tcp 127.0.0.1:2802: connect: connection refused
```
And doc looks like webui disabled by default and can be enabled by explicitly providing Webui.URL. Also currently webui cannot be disabled, because empty parameter value substituted by "http://localhost:2802".