### PR TITLE
Add listenaddress option

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -26,6 +27,7 @@ func getConfig() *types.Configuration {
 	kingpin.Parse()
 
 	v := viper.New()
+	v.SetDefault("ListenAddress", "")
 	v.SetDefault("ListenPort", 2801)
 	v.SetDefault("Debug", false)
 	v.SetDefault("CheckCert", true)
@@ -196,6 +198,10 @@ func getConfig() *types.Configuration {
 
 	if c.ListenPort == 0 || c.ListenPort > 65536 {
 		log.Fatalf("[ERROR] : Bad port number\n")
+	}
+
+	if ip := net.ParseIP(c.ListenAddress); c.ListenAddress != "" && ip == nil {
+		log.Fatalf("[ERROR] : Failed to parse ListenAddress")
 	}
 
 	c.Slack.MinimumPriority = checkPriority(c.Slack.MinimumPriority)

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,3 +1,4 @@
+#listenaddress: "" # ip address to bind falcosidekick to (default: "" meaning all addresses)
 #listenport: 2801 # port to listen for daemon (default: 2801)
 debug: false # if true all outputs will print in stdout the payload they send (default: false)
 customfields: # custom fields are added to falco events

--- a/falcosidekick.yaml
+++ b/falcosidekick.yaml
@@ -1,0 +1,2 @@
+alertmanager:
+  hostport: "http://armada-ops-alertmanager.monitoring.svc.cluster.local:9093"

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -371,12 +371,12 @@ func main() {
 	http.HandleFunc("/test", testHandler)
 	http.Handle("/metrics", promhttp.Handler())
 
-	log.Printf("[INFO]  : Falco Sidekick is up and listening on port %v\n", config.ListenPort)
+	log.Printf("[INFO]  : Falco Sidekick is up and listening on %s:%d", config.ListenAddress, config.ListenPort)
 	if config.Debug {
-		log.Printf("[INFO]  : Debug mode : %v\n", config.Debug)
+		log.Printf("[INFO]  : Debug mode : %v", config.Debug)
 	}
 
-	if err := http.ListenAndServe(":"+strconv.Itoa(config.ListenPort), nil); err != nil {
-		log.Fatalf("[ERROR] : %v\n", err.Error())
+	if err := http.ListenAndServe(fmt.Sprintf("%s:%d", config.ListenAddress, config.ListenPort), nil); err != nil {
+		log.Fatalf("[ERROR] : %v", err.Error())
 	}
 }

--- a/outputs/webui.go
+++ b/outputs/webui.go
@@ -3,7 +3,6 @@ package outputs
 import (
 	"encoding/json"
 	"expvar"
-	"fmt"
 	"log"
 
 	"github.com/falcosecurity/falcosidekick/types"
@@ -19,7 +18,9 @@ type WebUIPayload struct {
 func newWebUIPayload(falcopayload types.FalcoPayload, config *types.Configuration) WebUIPayload {
 	s := new(map[string]int64)
 
-	json.Unmarshal([]byte(fmt.Sprintf("%v", expvar.Get("falco.priority"))), &s)
+	if err := json.Unmarshal([]byte(expvar.Get("falco.priority").String()), &s); err != nil {
+		log.Printf("[ERROR] : WebUI - failed to unmarshal expvar : %s", err)
+	}
 
 	return WebUIPayload{
 		UUID:    config.UUID,

--- a/types/types.go
+++ b/types/types.go
@@ -22,6 +22,7 @@ type Configuration struct {
 	UUID          string
 	CheckCert     bool
 	Debug         bool
+	ListenAddress string
 	ListenPort    int
 	Customfields  map[string]string
 	Slack         SlackOutputConfig


### PR DESCRIPTION
I've added an explicit listenaddress option in addition to listenport.
In my particular use case I'm running falcosidekick in a net=host
container and don't want it to bind to external IPs.
Also fixed a gosec complaint about json.Unmarshal in webui.go

Signed-off-by: Al Stockdill-Mander <asm@uk.ibm.com>

/kind cleanup
/kind feature

/area config

**Special notes for your reviewer**:

I've removed the "\n" from log lines around the areas I have changed as they are not required, from https://golang.org/pkg/log/ "Every log message is output on a separate line: if the message being printed does not end in a newline, the logger will add one."

Also when resolving the gosec issue with json.Unmarshal in webui.go I changed the fmt.Sprintf to .String() on the Get() as https://golang.org/pkg/expvar/#Var specifies that
```
type Var interface {
    // String returns a valid JSON value for the variable.
    // Types with String methods that do not return valid JSON
    // (such as time.Time) must not be used as a Var.
    String() string
}
```