### PR TITLE
Fix: use HostPort insted of URL

### DIFF
--- a/config.go
+++ b/config.go
@@ -128,7 +128,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Googlechat.OutputFormat", "all")
 	v.SetDefault("Googlechat.MessageFormat", "")
 	v.SetDefault("Googlechat.MinimumPriority", "")
-	v.SetDefault("Kafka.URL", "")
+	v.SetDefault("Kafka.HostPort", "")
 	v.SetDefault("Kafka.Topic", "")
 	v.SetDefault("Kafka.Partition", 0)
 	v.SetDefault("Kafka.MinimumPriority", "")


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Kafka output settings work with `Kafka.HostPort` instead of `Kafka.URL`

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:


