### PR TITLE
Prevent misleading error message when setting CUSTOMFIELDS env var

### DIFF
--- a/config.go
+++ b/config.go
@@ -112,7 +112,6 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Dogstatsd.Forwarder", "")
 	v.SetDefault("Dogstatsd.Namespace", "falcosidekick.")
 	v.SetDefault("Dogstatsd.Tags", []string{})
-	v.SetDefault("Customfields", map[string]string{})
 	v.SetDefault("Webhook.Address", "")
 	v.SetDefault("Webhook.MinimumPriority", "")
 	v.SetDefault("CloudEvents.Address", "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area config


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This prevents this error from being printed out, which doesn't actually prevent CUSTOMFIELDS from being set properly via an environment variable
```
2021/03/03 15:36:59 [ERROR] : Error unmarshalling config : 1 error(s) decoding:

* 'Customfields' expected a map, got 'string'
```

This default also isn't actually needed since we already initialize an empty string map in the config struct. This makes the behavior of CUSTOMFIELDS the same as Webhook.CustomHeaders and CloudEvents.Extensions which don't set this default and don't have this issue.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


