### PR TITLE
Use higher level kafka Writer api instead of low level Conn api

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ googlechat:
 kafka:
   hostport: "" # Apache Kafka Host:Port (ex: localhost:9092). Defaults to port 9092 if no port is specified after the domain, if not empty, Kafka output is enabled
   topic: "" # Name of the topic, if not empty, Kafka output is enabled
-  # partition: 0 # Partition number of the topic.
   # minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 pagerduty:
@@ -532,7 +531,6 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **KAFKA_HOSTPORT**: The Host:Port of the Kafka (ex: localhost:9092), if not
   empty, Kafka is _enabled_
 - **KAFKA_TOPIC**: The name of the Kafka topic
-- **KAFKA_PARTITION**: The number of the Kafka partition
 - **KAFKA_MINIMUMPRIORITY**: minimum priority of event for using this output,
   order is
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`

--- a/config.go
+++ b/config.go
@@ -132,7 +132,6 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Googlechat.MinimumPriority", "")
 	v.SetDefault("Kafka.HostPort", "")
 	v.SetDefault("Kafka.Topic", "")
-	v.SetDefault("Kafka.Partition", 0)
 	v.SetDefault("Kafka.MinimumPriority", "")
 	v.SetDefault("Pagerduty.RoutingKey", "")
 	v.SetDefault("Pagerduty.MinimumPriority", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -156,7 +156,6 @@ googlechat:
 kafka:
   hostport: "" # Apache Kafka Host:Port (ex: localhost:9092). Defaults to port 9092 if no port is specified after the domain, if not empty, Kafka output is enabled
   topic: "" # Name of the topic, if not empty, Kafka output is enabled
-  # partition: 0 # Partition number of the topic.
   # minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 kubeless:

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -59,7 +59,7 @@ type Client struct {
 	StatsdClient      *statsd.Client
 	DogstatsdClient   *statsd.Client
 	GCPTopicClient    *pubsub.Topic
-	KafkaProducer     *kafka.Conn
+	KafkaProducer     *kafka.Writer
 	CloudEventsClient cloudevents.Client
 	KubernetesClient  kubernetes.Interface
 }

--- a/types/types.go
+++ b/types/types.go
@@ -257,7 +257,6 @@ type GooglechatConfig struct {
 type kafkaConfig struct {
 	HostPort        string
 	Topic           string
-	Partition       int
 	MinimumPriority string
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
If no messages to the kafka broker has been sent within `connections.max.idle.ms` set on the broker (default 10 minutes) then the connection gets closed. The existing way of setting up the kafka connection does not re-open the connection and fails with error messages like:
``` 
10.1.2.13:42642->10.2.3.4:9092: write: broken pipe
```

I also think it's an anti-pattern to explicitly set the partition number to write to, this means we cannot balance the load across multiple brokers.

---

From the kafka-go [readme](https://github.com/segmentio/kafka-go#writer-):

To produce messages to Kafka, a program may use the low-level `Conn` API, but
the package also provides a higher level `Writer` type which is more appropriate
to use in most cases as it provides additional features:

- Automatic retries and reconnections on errors.
- Configurable distribution of messages across available partitions.
- Synchronous or asynchronous writes of messages to Kafka.
- Asynchronous cancellation using contexts.
- Flushing of pending messages on close to support graceful shutdowns.

compared with: https://github.com/segmentio/kafka-go#connection-

The `Conn` type is the core of the `kafka-go` package. It wraps around a raw network connection to expose a low-level API to a Kafka server.

---

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


