### PR TITLE
Fix k8s pod and namespace labels for prometheus metrics

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -97,10 +97,10 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	var kn, kp string
 	for i, j := range falcopayload.OutputFields {
 		if i == "k8s.ns.name" {
-			kn = j.(string)
+			kn, _ = j.(string)
 		}
 		if i == "k8s.pod.name" {
-			kp = j.(string)
+			kp, _ = j.(string)
 		}
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -96,10 +96,10 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	var kn, kp string
 	for i, j := range falcopayload.OutputFields {
-		if i == "k8s_ns_name" {
+		if i == "k8s.ns.name" {
 			kn = j.(string)
 		}
-		if i == "k8s_pod_name" {
+		if i == "k8s.pod.name" {
 			kp = j.(string)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug
<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The field names sent in the output payload as defined [here](https://falco.org/docs/rules/supported-fields/) should be `k8s.pod.name` and `k8s.ns.name` without underscores. It's causing these fields to be missing in the prometheus metrics.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


