### PR TITLE
re-order fields for slack/rocket/mattermost + sort them alphabetically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/segmentio/kafka-go v0.4.10
 	github.com/spf13/viper v1.7.1
-	github.com/streadway/amqp v1.0.0 // indirect
+	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93
 	google.golang.org/api v0.40.0

--- a/outputs/googlechat.go
+++ b/outputs/googlechat.go
@@ -54,20 +54,13 @@ func newGooglechatPayload(falcopayload types.FalcoPayload, config *types.Configu
 		}
 	}
 
-	for i, j := range falcopayload.OutputFields {
-		var w widget
-		switch v := j.(type) {
-		case string:
-			w = widget{
-				KeyValue: keyValue{
-					TopLabel: i,
-					Content:  v,
-				},
-			}
-		default:
-			continue
+	for _, i := range getSortedStringKeys(falcopayload.OutputFields) {
+		w := widget{
+			KeyValue: keyValue{
+				TopLabel: i,
+				Content:  falcopayload.OutputFields[i].(string),
+			},
 		}
-
 		widgets = append(widgets, w)
 	}
 

--- a/outputs/mattermost.go
+++ b/outputs/mattermost.go
@@ -17,23 +17,6 @@ func newMattermostPayload(falcopayload types.FalcoPayload, config *types.Configu
 	)
 
 	if config.Mattermost.OutputFormat == All || config.Mattermost.OutputFormat == Fields || config.Mattermost.OutputFormat == "" {
-		for i, j := range falcopayload.OutputFields {
-			switch v := j.(type) {
-			case string:
-				field.Title = i
-				field.Value = v
-				if len([]rune(v)) < 36 {
-					field.Short = true
-				} else {
-					field.Short = false
-				}
-			default:
-				continue
-			}
-
-			fields = append(fields, field)
-		}
-
 		field.Title = Rule
 		field.Value = falcopayload.Rule
 		field.Short = true
@@ -42,6 +25,18 @@ func newMattermostPayload(falcopayload types.FalcoPayload, config *types.Configu
 		field.Value = falcopayload.Priority.String()
 		field.Short = true
 		fields = append(fields, field)
+
+		for _, i := range getSortedStringKeys(falcopayload.OutputFields) {
+			field.Title = i
+			field.Value = falcopayload.OutputFields[i].(string)
+			if len([]rune(falcopayload.OutputFields[i].(string))) < 36 {
+				field.Short = true
+			} else {
+				field.Short = false
+			}
+			fields = append(fields, field)
+		}
+
 		field.Title = Time
 		field.Short = false
 		field.Value = falcopayload.Time.String()

--- a/outputs/mattermost_test.go
+++ b/outputs/mattermost_test.go
@@ -23,11 +23,6 @@ func TestMattermostPayload(t *testing.T) {
 				Footer:   "https://github.com/falcosecurity/falcosidekick",
 				Fields: []slackAttachmentField{
 					{
-						Title: "proc.name",
-						Value: "falcosidekick",
-						Short: true,
-					},
-					{
 						Title: "rule",
 						Value: "Test rule",
 						Short: true,
@@ -35,6 +30,11 @@ func TestMattermostPayload(t *testing.T) {
 					{
 						Title: "priority",
 						Value: "Debug",
+						Short: true,
+					},
+					{
+						Title: "proc.name",
+						Value: "falcosidekick",
 						Short: true,
 					},
 					{

--- a/outputs/rocketchat.go
+++ b/outputs/rocketchat.go
@@ -17,23 +17,6 @@ func newRocketchatPayload(falcopayload types.FalcoPayload, config *types.Configu
 	)
 
 	if config.Rocketchat.OutputFormat == All || config.Rocketchat.OutputFormat == Fields || config.Rocketchat.OutputFormat == "" {
-		for i, j := range falcopayload.OutputFields {
-			switch v := j.(type) {
-			case string:
-				field.Title = i
-				field.Value = v
-				if len([]rune(v)) < 36 {
-					field.Short = true
-				} else {
-					field.Short = false
-				}
-			default:
-				continue
-			}
-
-			fields = append(fields, field)
-		}
-
 		field.Title = Rule
 		field.Value = falcopayload.Rule
 		field.Short = true
@@ -42,6 +25,18 @@ func newRocketchatPayload(falcopayload types.FalcoPayload, config *types.Configu
 		field.Value = falcopayload.Priority.String()
 		field.Short = true
 		fields = append(fields, field)
+
+		for _, i := range getSortedStringKeys(falcopayload.OutputFields) {
+			field.Title = i
+			field.Value = falcopayload.OutputFields[i].(string)
+			if len([]rune(falcopayload.OutputFields[i].(string))) < 36 {
+				field.Short = true
+			} else {
+				field.Short = false
+			}
+			fields = append(fields, field)
+		}
+
 		field.Title = Time
 		field.Short = false
 		field.Value = falcopayload.Time.String()

--- a/outputs/rocketchat_test.go
+++ b/outputs/rocketchat_test.go
@@ -23,11 +23,6 @@ func TestNewRocketchatPayload(t *testing.T) {
 				Footer:   "",
 				Fields: []slackAttachmentField{
 					{
-						Title: "proc.name",
-						Value: "falcosidekick",
-						Short: true,
-					},
-					{
 						Title: "rule",
 						Value: "Test rule",
 						Short: true,
@@ -35,6 +30,11 @@ func TestNewRocketchatPayload(t *testing.T) {
 					{
 						Title: "priority",
 						Value: "Debug",
+						Short: true,
+					},
+					{
+						Title: "proc.name",
+						Value: "falcosidekick",
 						Short: true,
 					},
 					{

--- a/outputs/slack.go
+++ b/outputs/slack.go
@@ -40,25 +40,7 @@ func newSlackPayload(falcopayload types.FalcoPayload, config *types.Configuratio
 		fields      []slackAttachmentField
 		field       slackAttachmentField
 	)
-
 	if config.Slack.OutputFormat == All || config.Slack.OutputFormat == Fields || config.Slack.OutputFormat == "" {
-		for i, j := range falcopayload.OutputFields {
-			switch v := j.(type) {
-			case string:
-				field.Title = i
-				field.Value = v
-				if len([]rune(v)) < 36 {
-					field.Short = true
-				} else {
-					field.Short = false
-				}
-			default:
-				continue
-			}
-
-			fields = append(fields, field)
-		}
-
 		field.Title = Rule
 		field.Value = falcopayload.Rule
 		field.Short = true
@@ -67,6 +49,18 @@ func newSlackPayload(falcopayload types.FalcoPayload, config *types.Configuratio
 		field.Value = falcopayload.Priority.String()
 		field.Short = true
 		fields = append(fields, field)
+
+		for _, i := range getSortedStringKeys(falcopayload.OutputFields) {
+			field.Title = i
+			field.Value = falcopayload.OutputFields[i].(string)
+			if len([]rune(falcopayload.OutputFields[i].(string))) < 36 {
+				field.Short = true
+			} else {
+				field.Short = false
+			}
+			fields = append(fields, field)
+		}
+
 		field.Title = Time
 		field.Short = false
 		field.Value = falcopayload.Time.String()

--- a/outputs/slack_test.go
+++ b/outputs/slack_test.go
@@ -23,11 +23,6 @@ func TestNewSlackPayload(t *testing.T) {
 				Footer:   "https://github.com/falcosecurity/falcosidekick",
 				Fields: []slackAttachmentField{
 					{
-						Title: "proc.name",
-						Value: "falcosidekick",
-						Short: true,
-					},
-					{
 						Title: "rule",
 						Value: "Test rule",
 						Short: true,
@@ -35,6 +30,11 @@ func TestNewSlackPayload(t *testing.T) {
 					{
 						Title: "priority",
 						Value: "Debug",
+						Short: true,
+					},
+					{
+						Title: "proc.name",
+						Value: "falcosidekick",
 						Short: true,
 					},
 					{

--- a/outputs/utils.go
+++ b/outputs/utils.go
@@ -1,0 +1,17 @@
+package outputs
+
+import "sort"
+
+func getSortedStringKeys(m map[string]interface{}) []string {
+	var keys []string
+	for i, j := range m {
+		switch j.(type) {
+		case string:
+			keys = append(keys, i)
+		default:
+			continue
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Signed-off-by: Issif <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR orders the fields in "chat" outputs (`Slack`, `Mattermost`, `Rocketchat`).

![image](https://user-images.githubusercontent.com/4520100/114452792-25d72f80-9bd9-11eb-8a1e-930b5c5cda4e.png)

**Which issue(s) this PR fixes**:

#223 

Fixes #

**Special notes for your reviewer**:


