### PR TITLE
Add Workload Identity to GCP Output

### DIFF
--- a/outputs/gcp.go
+++ b/outputs/gcp.go
@@ -45,7 +45,6 @@ func NewGCPClient(config *types.Configuration, stats *types.Statistics, promStat
 			}
 			topicClient = pubSubClient.Topic(config.GCP.PubSub.Topic)
 		} else {
-			log.Printf("Workload Identity!")
 			pubSubClient, err := pubsub.NewClient(context.Background(), config.GCP.PubSub.ProjectID)
 			if err != nil {
 				log.Printf("[ERROR] : GCP PubSub - %v\n", "Error while creating GCP PubSub Client")

--- a/types/types.go
+++ b/types/types.go
@@ -249,9 +249,10 @@ type eventHub struct {
 }
 
 type gcpOutputConfig struct {
-	Credentials string
-	PubSub      gcpPubSub
-	Storage     gcpStorage
+	Credentials      string
+	WorkloadIdentity bool
+	PubSub           gcpPubSub
+	Storage          gcpStorage
 }
 
 type gcpPubSub struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This is a small PR to enable the usage of [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for GCP pubsub. If no GCP credentials are passed in but the Topic and Project fields are populated it will now assume WorkloadIdentity is the intended option. I am not sure if having a flag open for "enabling" this would be better as it is more explicit but would not actually enable it.

The goal is to remove the need to pass in a GCP credentials file to Falcosidekick and help prevent the need to download and manage service accounts.

To test workloadidentity first create a GCP cluster with workloadidentity enabled
```
gcloud container clusters create $CLUSTER_NAME \
--workload-pool ${PROJECT_ID}.svc.id.goog
```

Install Falco w/ falcosidekick
```
helm install falco falcosecurity/falco \
--namespace $FALCO_NAMESPACE \
--set ebpf.enabled=true \
--set falcosidekick.enabled=true \
--set falcosidekick.config.gcp.pubsub.projectid=${PROJECT_ID} \
--set falcosidekick.config.gcp.pubsub.topic=${PUBSUB_TOPIC} \
--set falcosidekick.webui.enabled=true
```
Create your SA and Rolebindings
```
gcloud iam service-accounts create $SA_ACCOUNT

gcloud projects add-iam-policy-binding ${PROJECT_ID} \
--member="serviceAccount:${SA_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com" \
--role="roles/pubsub.publisher"
```

Finally set up the Falcosidekick SA to impersonate a GCP SA
```
gcloud iam service-accounts add-iam-policy-binding \
  --role roles/iam.workloadIdentityUser \
  --member "serviceAccount:${PROJECT_ID}.svc.id.goog[${FALCO_NAMESPACE}/falco-falcosidekick]" \
  ${SA_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com

kubectl annotate serviceaccount \
  --namespace $FALCO_NAMESPACE \
  falco-falcosidekick \
  iam.gke.io/gcp-service-account=${SA_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


