### PR TITLE
Reorg Headers, Add Basic Auth for Elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ elasticsearch:
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
-  # username: "" # use this username to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
-  # password: "" # use this password to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
+  # username: "" # use this username to authenticate to Elasticsearch if the username is not empty (default: "")
+  # password: "" # use this password to authenticate to Elasticsearch if the password is not empty (default: "")
 
 influxdb:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Influxdb output is enabled

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ elasticsearch:
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # username: "" # use this username to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
+  # password: "" # use this password to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
 
 influxdb:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Influxdb output is enabled
@@ -487,6 +489,10 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   `false`)
 - **ELASTICSEARCH_CHECKCERT** : check if ssl certificate of the output is valid (default:
   `true`)
+- **ELASTICSEARCH_USERNAME** : use this username to authenticate to Elasticsearch if the
+  username is not empty (default: "")
+- **ELASTICSEARCH_PASSWORD** : use this password to authenticate to Elasticsearch if the
+  password is not empty (default: "")
 - **INFLUXDB_HOSTPORT** : Influxdb http://host:port, if not `empty`, Influxdb is
   _enabled_
 - **INFLUXDB_DATABASE** : Influxdb database (default: falco)

--- a/config.go
+++ b/config.go
@@ -85,6 +85,8 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Elasticsearch.Suffix", "daily")
 	v.SetDefault("Elasticsearch.MutualTls", false)
 	v.SetDefault("Elasticsearch.CheckCert", true)
+	v.SetDefault("Elasticsearch.Username", "")
+	v.SetDefault("Elasticsearch.Password", "")
 	v.SetDefault("Influxdb.HostPort", "")
 	v.SetDefault("Influxdb.Database", "falco")
 	v.SetDefault("Influxdb.User", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -62,6 +62,8 @@ elasticsearch:
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # username: "" # use this username to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
+  # password: "" # use this password to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
 
 influxdb:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Influxdb output is enabled

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -62,8 +62,8 @@ elasticsearch:
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
-  # username: "" # use this username to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
-  # password: "" # use this password to perform HTTP Basic Auth to the Elasticsearch server. Do not perform auth if this parameter is empty.
+  # username: "" # use this username to authenticate to Elasticsearch if the username is not empty (default: "")
+  # password: "" # use this password to authenticate to Elasticsearch if the password is not empty (default: "")
 
 influxdb:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Influxdb output is enabled

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -232,6 +232,7 @@ func (c *Client) Post(payload interface{}) error {
 	}
 }
 
+// BasicAuth adds an HTTP Basic Authentication compliant header to the Client.
 func (c *Client) BasicAuth(username, password string) {
 	// Check out RFC7617 for the specifics on this code.
 	// https://datatracker.ietf.org/doc/html/rfc7617
@@ -241,6 +242,7 @@ func (c *Client) BasicAuth(username, password string) {
 	c.AddHeader(AuthorizationHeaderKey, "Basic "+b64UserPass)
 }
 
+// AddHeader adds an HTTP Header to the Client.
 func (c *Client) AddHeader(key, value string) {
 	c.HeaderList = append(c.HeaderList, Header{Key: key, Value: value})
 }

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -35,7 +35,7 @@ func TestNewClient(t *testing.T) {
 	stats := &types.Statistics{}
 	promStats := &types.PromStatistics{}
 
-	testClientOutput := Client{OutputType: "test", EndpointURL: u, MutualTLSEnabled: false, Config: config, Stats: stats, PromStats: promStats}
+	testClientOutput := Client{OutputType: "test", EndpointURL: u, MutualTLSEnabled: false, HeaderList: []Header{}, ContentType: "application/json; charset=utf-8", Config: config, Stats: stats, PromStats: promStats}
 	_, err := NewClient("test", "localhost/%*$¨^!/:;", false, true, config, stats, promStats, nil, nil)
 	require.NotNil(t, err)
 

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -140,6 +140,9 @@ func TestAddBasicAuth(t *testing.T) {
 
 		require.Equal(t, passedUsername, username)
 		require.Equal(t, passedPassword, password)
+		// I used https://www.base64encode.org/ to encode "user:pass" in base64,
+		// and that should be the provided value.
+		require.Equal(t, digest, "dXNlcjpwYXNz")
 	}))
 	nc, err := NewClient("", ts.URL, false, true, &types.Configuration{}, &types.Statistics{}, &types.PromStatistics{}, nil, nil)
 	require.Nil(t, err)

--- a/outputs/elasticsearch.go
+++ b/outputs/elasticsearch.go
@@ -33,6 +33,10 @@ func (c *Client) ElasticsearchPost(falcopayload types.FalcoPayload) {
 	}
 
 	c.EndpointURL = endpointURL
+	if c.Config.Elasticsearch.Username != "" && c.Config.Elasticsearch.Password != "" {
+		c.BasicAuth(c.Config.Elasticsearch.Username, c.Config.Elasticsearch.Password)
+	}
+
 	err = c.Post(falcopayload)
 	if err != nil {
 		c.setElasticSearchErrorMetrics()

--- a/outputs/gcpcloudrun.go
+++ b/outputs/gcpcloudrun.go
@@ -9,7 +9,9 @@ import (
 // CloudRunFunctionPost call Cloud Function
 func (c *Client) CloudRunFunctionPost(falcopayload types.FalcoPayload) {
 	c.Stats.GCPCloudRun.Add(Total, 1)
-
+	if c.Config.GCP.CloudRun.JWT != "" {
+		c.AddHeader("Authorization", "Bearer "+c.Config.GCP.CloudRun.JWT)
+	}
 	err := c.Post(falcopayload)
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:gcpcloudrun", "status:error"})

--- a/outputs/gcpcloudrun.go
+++ b/outputs/gcpcloudrun.go
@@ -9,9 +9,11 @@ import (
 // CloudRunFunctionPost call Cloud Function
 func (c *Client) CloudRunFunctionPost(falcopayload types.FalcoPayload) {
 	c.Stats.GCPCloudRun.Add(Total, 1)
+
 	if c.Config.GCP.CloudRun.JWT != "" {
-		c.AddHeader("Authorization", "Bearer "+c.Config.GCP.CloudRun.JWT)
+		c.AddHeader(AuthorizationHeaderKey, "Bearer "+c.Config.GCP.CloudRun.JWT)
 	}
+
 	err := c.Post(falcopayload)
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:gcpcloudrun", "status:error"})

--- a/outputs/kubeless.go
+++ b/outputs/kubeless.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Some constant strings to use in request headers
-const KubelessEventIdKey = "event-id"
+const KubelessEventIDKey = "event-id"
 const KubelessUserAgentKey = "User-Agent"
 const KubelessEventTypeKey = "event-type"
 const KubelessEventNamespaceKey = "event-namespace"
@@ -63,7 +63,7 @@ func (c *Client) KubelessCall(falcopayload types.FalcoPayload) {
 	if c.Config.Kubeless.Kubeconfig != "" {
 		str, _ := json.Marshal(falcopayload)
 		req := c.KubernetesClient.CoreV1().RESTClient().Post().AbsPath("/api/v1/namespaces/" + c.Config.Kubeless.Namespace + "/services/" + c.Config.Kubeless.Function + ":" + strconv.Itoa(c.Config.Kubeless.Port) + "/proxy/").Body(str)
-		req.SetHeader(KubelessEventIdKey, uuid.New().String())
+		req.SetHeader(KubelessEventIDKey, uuid.New().String())
 		req.SetHeader(ContentTypeHeaderKey, KubelessContentType)
 		req.SetHeader(UserAgentHeaderKey, UserAgentHeaderValue)
 		req.SetHeader(KubelessEventTypeKey, KubelessEventTypeValue)
@@ -80,7 +80,7 @@ func (c *Client) KubelessCall(falcopayload types.FalcoPayload) {
 		}
 		log.Printf("[INFO]  : Kubeless - Function Response : %v\n", string(rawbody))
 	} else {
-		c.AddHeader(KubelessEventIdKey, uuid.New().String())
+		c.AddHeader(KubelessEventIDKey, uuid.New().String())
 		c.AddHeader(KubelessEventTypeKey, KubelessEventTypeValue)
 		c.AddHeader(KubelessEventNamespaceKey, c.Config.Kubeless.Namespace)
 		c.ContentType = KubelessContentType

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -23,7 +23,7 @@ type lokiEntry struct {
 }
 
 // The Content-Type to send along with the request
-const lokiContentType = "application/json"
+const LokiContentType = "application/json"
 
 func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration) lokiPayload {
 	le := lokiEntry{Ts: falcopayload.Time.Format(time.RFC3339), Line: falcopayload.Output}
@@ -50,7 +50,8 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 // LokiPost posts event to Loki
 func (c *Client) LokiPost(falcopayload types.FalcoPayload) {
 	c.Stats.Loki.Add(Total, 1)
-	c.ContentType = lokiContentType
+	c.ContentType = LokiContentType
+
 	err := c.Post(newLokiPayload(falcopayload, c.Config))
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:loki", "status:error"})

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -22,6 +22,9 @@ type lokiEntry struct {
 	Line string `json:"line"`
 }
 
+// The Content-Type to send along with the request
+const lokiContentType = "application/json"
+
 func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration) lokiPayload {
 	le := lokiEntry{Ts: falcopayload.Time.Format(time.RFC3339), Line: falcopayload.Output}
 	ls := lokiStream{Entries: []lokiEntry{le}}
@@ -47,7 +50,7 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 // LokiPost posts event to Loki
 func (c *Client) LokiPost(falcopayload types.FalcoPayload) {
 	c.Stats.Loki.Add(Total, 1)
-
+	c.ContentType = lokiContentType
 	err := c.Post(newLokiPayload(falcopayload, c.Config))
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:loki", "status:error"})

--- a/outputs/opsgenie.go
+++ b/outputs/opsgenie.go
@@ -51,7 +51,8 @@ func newOpsgeniePayload(falcopayload types.FalcoPayload, config *types.Configura
 // OpsgeniePost posts event to OpsGenie
 func (c *Client) OpsgeniePost(falcopayload types.FalcoPayload) {
 	c.Stats.Opsgenie.Add(Total, 1)
-	c.AddHeader("Authorization", "GenieKey "+c.Config.Opsgenie.APIKey)
+	c.AddHeader(AuthorizationHeaderKey, "GenieKey "+c.Config.Opsgenie.APIKey)
+
 	err := c.Post(newOpsgeniePayload(falcopayload, c.Config))
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:opsgenie", "status:error"})

--- a/outputs/opsgenie.go
+++ b/outputs/opsgenie.go
@@ -51,7 +51,7 @@ func newOpsgeniePayload(falcopayload types.FalcoPayload, config *types.Configura
 // OpsgeniePost posts event to OpsGenie
 func (c *Client) OpsgeniePost(falcopayload types.FalcoPayload) {
 	c.Stats.Opsgenie.Add(Total, 1)
-
+	c.AddHeader("Authorization", "GenieKey "+c.Config.Opsgenie.APIKey)
 	err := c.Post(newOpsgeniePayload(falcopayload, c.Config))
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:opsgenie", "status:error"})

--- a/outputs/webhook.go
+++ b/outputs/webhook.go
@@ -10,6 +10,12 @@ import (
 func (c *Client) WebhookPost(falcopayload types.FalcoPayload) {
 	c.Stats.Webhook.Add(Total, 1)
 
+	if len(c.Config.Webhook.CustomHeaders) != 0 {
+		for i, j := range c.Config.Webhook.CustomHeaders {
+			c.AddHeader(i, j)
+		}
+	}
+
 	err := c.Post(falcopayload)
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:webhook", "status:error"})

--- a/types/types.go
+++ b/types/types.go
@@ -148,6 +148,8 @@ type elasticsearchOutputConfig struct {
 	Type            string
 	MinimumPriority string
 	Suffix          string
+	Username        string
+	Password        string
 	CheckCert       bool
 	MutualTLS       bool
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area outputs

/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Elasticsearch primarily supports Basic Authentication as the means of authenticating to the server. This PR should allow users to use HTTP Basic Authentication with Elasticsearch. There was an attempt to make it easy to apply Basic Authentication to other providers as well, though no other output providers are configured in this PR.

This PR also cleans up the Post method in client.go to force the outputs to set the headers in their own Post methods.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

N/A

**Special notes for your reviewer**:

Previously: I'm going to get to the tests eventually. Trust me.

Now: Maybe I got to the tests? Maybe?
