### PR TITLE
Nats only needs one YAML block.

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -90,12 +90,6 @@ stan:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
-  
-nats:
-  # hostport: "" # nats://{domain or ip}:{port}, if not empty, NATS output is enabled
-  # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-  # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
-  # checkcert: true # check if ssl certificate of the output is valid (default: true)
 
 aws:
   # accesskeyid: "" # aws access key (optional if you use EC2 Instance Profile)


### PR DESCRIPTION
Signed-off-by: Tom Kelley <distortedsignal@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind cleanup


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

Documentation?


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

There were two `nats` blocks in the config_example.yaml. This PR should remove one.

I think that having two blocks in YAML with the same name is an error (or my text editor is reporting that it is).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->
N/A

**Special notes for your reviewer**:

This is really low priority. Feel free to ignore.
