### PR TITLE
Prevent memory leak in headers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ falcosidekick:
 
 .PHONY: build-image
 build-image:
-	$(DOCKER) build . -t falcosecurity/falcosidekick:latest
+	$(DOCKER) build . -t distortedsignal/falcosidekick:latest
 
 ## --------------------------------------
 ## Test

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ falcosidekick:
 
 .PHONY: build-image
 build-image:
-	$(DOCKER) build . -t distortedsignal/falcosidekick:latest
+	$(DOCKER) build . -t falcosecurity/falcosidekick:latest
 
 ## --------------------------------------
 ## Test

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -195,6 +195,9 @@ func (c *Client) Post(payload interface{}) error {
 	}
 	defer resp.Body.Close()
 
+	// Clear out headers - they will be set for the next request.
+	c.HeaderList = []Header{}
+
 	go c.CountMetric("outputs", 1, []string{"output:" + strings.ToLower(c.OutputType), "status:" + strings.ToLower(http.StatusText(resp.StatusCode))})
 
 	switch resp.StatusCode {

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -154,7 +154,7 @@ func TestAddBasicAuth(t *testing.T) {
 }
 
 func TestHeadersResetAfterReq(t *testing.T) {
-	headerKey, headerVal := "Key", "Val"
+	headerKey, headerVal := http.CanonicalHeaderKey("key"), "val"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		passedList := r.Header[headerKey]
 		require.Equal(t, 1, len(passedList), "Expected %v to have 1 element", passedList)

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -153,6 +153,26 @@ func TestAddBasicAuth(t *testing.T) {
 	nc.Post("")
 }
 
+func TestHeadersResetAfterReq(t *testing.T) {
+	headerKey, headerVal := "Key", "Val"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		passedList := r.Header[headerKey]
+		require.Equal(t, 1, len(passedList), "Expected %v to have 1 element", passedList)
+	}))
+
+	nc, err := NewClient("", ts.URL, false, true, &types.Configuration{}, &types.Statistics{}, &types.PromStatistics{}, nil, nil)
+	require.Nil(t, err)
+	require.NotEmpty(t, nc)
+
+	nc.AddHeader(headerKey, headerVal)
+
+	nc.Post("")
+
+	nc.AddHeader(headerKey, headerVal)
+
+	nc.Post("")
+}
+
 func TestMutualTlsPost(t *testing.T) {
 	config := &types.Configuration{}
 	config.MutualTLSFilesPath = "/tmp/falcosidekicktests"


### PR DESCRIPTION
Signed-off-by: Tom Kelley <distortedsignal@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

[Somebody](https://github.com/distortedsignal/) [made a PR](https://github.com/falcosecurity/falcosidekick/pull/245) that contained a memory leak for most of the outputs in the Falcosidekick. Since the header list was never reset and the output objects are long-lived (they're not recreated for each POST), headers would populate across request boundaries. For most outputs, this would be a major problem. For the `Kubeless` output, this is a critical problem since an event-id is generated for each event/POST request.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

N/A

**Special notes for your reviewer**:

I'm sorry that this happened, and I'll try not to let it happen again.
