### PR TITLE
set header x-amz-acl to bucket-owner-full-control

### DIFF
--- a/outputs/aws.go
+++ b/outputs/aws.go
@@ -153,6 +153,7 @@ func (c *Client) UploadS3(falcopayload types.FalcoPayload) {
 		Bucket: aws.String(c.Config.AWS.S3.Bucket),
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(f),
+		ACL:    aws.String(s3.ObjectCannedACLBucketOwnerFullControl),
 	})
 	if err != nil {
 		go c.CountMetric("outputs", 1, []string{"output:awss3", "status:error"})


### PR DESCRIPTION
Signed-off-by: Kaizhe Huang <derek0405@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

 /area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

For scenarios that falcosidekick does not own the s3 bucket, we should allow to grant the object privileges to bucket owner. By default, the bucket owner do not have access on the objects created by falcosidekick from different aws accounts. For more details: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html

**Which issue(s) this PR fixes**:

N/A

Fixes #

**Special notes for your reviewer**:


