### PR TITLE
ci: include required deps for build and push to ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,6 @@ executors:
   default:
     docker:
     - image: circleci/golang:1.16.0
-  docker-build:
-    docker:
-    - image: docker:stable
 
 jobs:
   lint:
@@ -44,7 +41,7 @@ jobs:
 
   build-push-ecr:
     executor:
-      name: docker-build
+      name: default
     steps:
     - checkout
     - setup_remote_docker


### PR DESCRIPTION
Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR includes the missing but required dependencies on the build and artifact publish job to AWS ECR.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

The previous container image (`docker:stable`) did not include the required GNU Make.
