### PR TITLE
ci: add missing bash dep on push to ecr job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     - run:
         command: |
           apk update
-          apk add --update make
+          apk add --update make bash
           make build-image
     - run:
         command: |


### PR DESCRIPTION
Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

This PR includes the missing but required dependencies on the build and artifact publish job to AWS ECR.

**Which issue(s) this PR fixes**:

NONE