### PR TITLE
Add priority label to alertmanager alerts

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -75,6 +75,7 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPaylo
 	}
 	amPayload.Labels["source"] = "falco"
 	amPayload.Labels["rule"] = falcopayload.Rule
+	amPayload.Labels["priority"] = falcopayload.Priority.String()
 
 	amPayload.Annotations["info"] = falcopayload.Output
 	amPayload.Annotations["summary"] = falcopayload.Rule

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewAlertmanagerPayloadO(t *testing.T) {
-	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","proc_tty":"1234","rule":"Test rule","source":"falco"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
+	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","rule":"Test rule","source":"falco"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
 
 	var f types.FalcoPayload
 	d := json.NewDecoder(strings.NewReader(falcoTestInput))


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

Adds the "priority" field from Falco as an alertmanager Label. Helps users route alerts to different notification backends based on priority.

**Which issue(s) this PR fixes**:

Fixes #275 

**Special notes for your reviewer**:

You were right @Issif , that was easy!
