### PR TITLE
Add Alertmanager variable to choose the endpoint version of Alertmanager api

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ alertmanager:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
+
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
@@ -543,6 +545,8 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   `false`)
 - **ALERTMANAGER_CHECKCERT** : check if ssl certificate of the output is valid (default:
   `true`)
+- **ALERTMANAGER_ENDPOINT** : alertmanager endpoint on which falcosidekick posts alerts, choice is:
+  `"/api/v1/alerts" or "/api/v2/alerts" , default is "/api/v1/alerts"`
 - **ELASTICSEARCH_HOSTPORT** : Elasticsearch http://host:port, if not `empty`,
   Elasticsearch is _enabled_
 - **ELASTICSEARCH_INDEX** : Elasticsearch index (default: falco)

--- a/config.go
+++ b/config.go
@@ -85,6 +85,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Alertmanager.MinimumPriority", "")
 	v.SetDefault("Alertmanager.MutualTls", false)
 	v.SetDefault("Alertmanager.CheckCert", true)
+	v.SetDefault("Alertmanager.Endpoint", "/api/v1/alerts")
 
 	v.SetDefault("Elasticsearch.HostPort", "")
 	v.SetDefault("Elasticsearch.Index", "falco")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -53,6 +53,7 @@ alertmanager:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func init() {
 
 	if config.Alertmanager.HostPort != "" {
 		var err error
-		alertmanagerClient, err = outputs.NewClient("AlertManager", config.Alertmanager.HostPort+outputs.AlertmanagerURI, config.Alertmanager.MutualTLS, config.Alertmanager.CheckCert, config, stats, promStats, statsdClient, dogstatsdClient)
+		alertmanagerClient, err = outputs.NewClient("AlertManager", config.Alertmanager.HostPort+config.Alertmanager.Endpoint, config.Alertmanager.MutualTLS, config.Alertmanager.CheckCert, config, stats, promStats, statsdClient, dogstatsdClient)
 		if err != nil {
 			config.Alertmanager.HostPort = ""
 		} else {

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -9,10 +9,6 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
-const (
-	// AlertmanagerURI is default endpoint where to send events
-	AlertmanagerURI string = "/api/v1/alerts"
-)
 
 type alertmanagerPayload struct {
 	Labels      map[string]string `json:"labels,omitempty"`

--- a/types/types.go
+++ b/types/types.go
@@ -145,6 +145,7 @@ type alertmanagerOutputConfig struct {
 	MinimumPriority string
 	CheckCert       bool
 	MutualTLS       bool
+	Endpoint        string
 }
 
 type elasticsearchOutputConfig struct {


### PR DESCRIPTION


Signed-off-by: Mathilde Hermet <mathildehermet94260@gmail.com>

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area config

> /area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->
   
**What this PR does / why we need it**:   
   
There are two versions of Alertmanager endpoint to post alerts: v1 and v2.   
Previously, this endpoint was hardcoded with v1.   
As a result, an upgrade of Alertmanager might leads to an impossible communication between Falcosidekick and Alertmanager.   
   
**Which issue(s) this PR fixes**:   
Fixes #280


