### PR TITLE
build binaries and image for arm64 and arm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,47 @@ executors:
     docker:
     - image: docker:stable
 
+install_buildx: &install_buildx
+  name: Install Docker buildx
+  command: |
+    mkdir -p ~/.docker/cli-plugins
+    curl -sSL -o ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64
+    chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+setup_docker_multiarch: &setup_docker_multiarch
+  name: Create Docker context
+  command: |
+    docker context create falco-environment
+    docker buildx install
+    docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+    docker buildx create --name docker-multiarch falco-environment \
+      --platform linux/amd64,linux/arm/v7,linux/arm64
+    docker buildx inspect --builder docker-multiarch --bootstrap
+    docker buildx use docker-multiarch
+
+install_goreleaser: &install_goreleaser
+  name: Install goreleaser
+  command: |
+    GORELEASER_URL="https://github.com/goreleaser/goreleaser/releases/download/v1.1.0/goreleaser_Linux_x86_64.tar.gz"
+
+    curl --output goreleaser_Linux_x86_64.tar.gz \
+      --silent --show-error --location --fail --retry 3 \
+      "$GORELEASER_URL"
+
+    sudo mkdir -p /usr/local/goreleaser
+    sudo tar -C /usr/local/goreleaser -xzf goreleaser_Linux_x86_64.tar.gz
+    export PATH=$PATH:/usr/local/goreleaser
+    goreleaser --version
+
+install_awscli: &install_awscli
+  name: Install pre-requisites
+  command: |
+    DIR=$(mktemp -d) && pushd $DIR
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    unzip awscliv2.zip
+    ./aws/install -i $HOME/.local/aws-cli -b $HOME/.local/bin
+    popd && rm -r $DIR
+
 jobs:
   lint:
     executor:
@@ -25,13 +66,22 @@ jobs:
   build-image:
     executor:
       name: default
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
     - checkout
     - setup_remote_docker
+    - run: *install_buildx
+    - run: *setup_docker_multiarch
+    - run: *install_goreleaser
     - run:
         command: |
-          make build-image
-          docker run falcosecurity/falcosidekick:latest --help
+          export PATH=$PATH:/usr/local/goreleaser
+          goreleaser --snapshot --rm-dist
+          docker images
+          docker run falcosecurity/falcosidekick:latest-amd64 --help
 
   build-push-main:
     executor:
@@ -39,93 +89,73 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
+    - run: *install_buildx
+    - run: *setup_docker_multiarch
+    - run: *install_goreleaser
     - run:
         command: |
-          make build-image
-          docker run falcosecurity/falcosidekick:latest --help
+          export PATH=$PATH:/usr/local/goreleaser
+          goreleaser --snapshot --rm-dist
+          docker run falcosecurity/falcosidekick:latest-amd64 --help
     - run:
         command: |
           echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-          docker push falcosecurity/falcosidekick:latest
+          docker push falcosecurity/falcosidekick:latest-amd64
+          docker push falcosecurity/falcosidekick:latest-arm64
+          docker push falcosecurity/falcosidekick:latest-armv7
+          docker manifest create --amend falcosecurity/falcosidekick:latest falcosecurity/falcosidekick:latest-amd64 \
+            falcosecurity/falcosidekick:latest-arm64 falcosecurity/falcosidekick:latest-armv7
+          docker manifest push --purge falcosecurity/falcosidekick:latest
 
   build-push-ecr:
     executor:
-      name: docker-build
+      name: default
     steps:
     - checkout
     - setup_remote_docker
+    - run: *install_buildx
+    - run: *setup_docker_multiarch
+    - run: *install_goreleaser
+    - run: *install_awscli
     - run:
         command: |
-          apk update
-          apk add --update make bash
-          make build-image
-          docker run falcosecurity/falcosidekick:latest --help
+          export PATH=$PATH:/usr/local/goreleaser
+          goreleaser --snapshot --rm-dist
+          docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --help
     - run:
         command: |
-          docker tag falcosecurity/falcosidekick:latest \
-            public.ecr.aws/falcosecurity/falcosidekick:latest
-    - run:
-        command: |
-          apk update
-          apk add --update groff less py-pip
-          pip install awscli
           aws ecr-public get-login-password --region us-east-1 | \
             docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-          docker push public.ecr.aws/falcosecurity/falcosidekick:latest
+          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-amd64
+          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-arm64
+          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-armv7
+          docker manifest create --amend public.ecr.aws/falcosecurity/falcosidekick:latest public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 \
+            public.ecr.aws/falcosecurity/falcosidekick:latest-arm64 public.ecr.aws/falcosecurity/falcosidekick:latest-armv7
+          docker manifest push --purge public.ecr.aws/falcosecurity/falcosidekick:latest
 
   release:
-    machine:
-      image: ubuntu-2004:202111-01
+    executor:
+      name: default
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - checkout
-      - run:
-          name: Update Go
-          command: |
-            GOLANG_URL="https://go.dev/dl/go1.16.11.linux-amd64.tar.gz"
-
-            curl --output go1.16.11.linux-amd64.tar.gz \
-              --silent --show-error --location --fail --retry 3 \
-              "$GOLANG_URL"
-
-            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.11.linux-amd64.tar.gz
-            go version
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64"
-
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-
-            mkdir -p ~/.docker/cli-plugins
-
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-      - run:
-          name: Install pre-requisites
-          command: |
-            DIR=$(mktemp -d) && pushd $DIR
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            ./aws/install -i $HOME/.local/aws-cli -b $HOME/.local/bin
-            popd && rm -r $DIR
-      - run:
-          name: Login Registries
-          command: |
-            echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-            aws ecr-public get-login-password --region us-east-1 | \
-              docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-      - run:
-          name: Release
-          command: curl -sL https://git.io/goreleaser | bash
+    - checkout
+    - setup_remote_docker
+    - run: *install_buildx
+    - run: *setup_docker_multiarch
+    - run: *install_goreleaser
+    - run: *install_awscli
+    - run:
+        name: Login Registries
+        command: |
+          echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
+          aws ecr-public get-login-password --region us-east-1 | \
+            docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
+    - run:
+        name: Release
+        command: goreleaser release --rm-dist
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-    - image: circleci/golang:1.16.0
-  docker-build:
-    docker:
-    - image: docker:stable
+    - image: cimg/go:1.16.11
 
 install_buildx: &install_buildx
   name: Install Docker buildx

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,10 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - run: make build-image
+    - run:
+        command: |
+          make build-image
+          docker run falcosecurity/falcosidekick:latest --help
 
   build-push-main:
     executor:
@@ -36,7 +39,10 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - run: make build-image
+    - run:
+        command: |
+          make build-image
+          docker run falcosecurity/falcosidekick:latest --help
     - run:
         command: |
           echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
@@ -53,6 +59,7 @@ jobs:
           apk update
           apk add --update make bash
           make build-image
+          docker run falcosecurity/falcosidekick:latest --help
     - run:
         command: |
           docker tag falcosecurity/falcosidekick:latest \
@@ -67,11 +74,41 @@ jobs:
           docker push public.ecr.aws/falcosecurity/falcosidekick:latest
 
   release:
-    executor:
-      name: default
+    machine:
+      image: ubuntu-2004:202111-01
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
     steps:
       - checkout
-      - setup_remote_docker
+      - run:
+          name: Update Go
+          command: |
+            GOLANG_URL="https://go.dev/dl/go1.16.11.linux-amd64.tar.gz"
+
+            curl --output go1.16.11.linux-amd64.tar.gz \
+              --silent --show-error --location --fail --retry 3 \
+              "$GOLANG_URL"
+
+            sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.11.linux-amd64.tar.gz
+            go version
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.7.0/buildx-v0.7.0.linux-amd64"
+
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+
+            mkdir -p ~/.docker/cli-plugins
+
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
       - run:
           name: Install pre-requisites
           command: |
@@ -81,7 +118,7 @@ jobs:
             ./aws/install -i $HOME/.local/aws-cli -b $HOME/.local/bin
             popd && rm -r $DIR
       - run:
-          name: Prepare env
+          name: Login Registries
           command: |
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
             aws ecr-public get-login-password --region us-east-1 | \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,45 +1,111 @@
 project_name: falcosidekick
+
+snapshot:
+  name_template: '{{ incpatch .Version }}-next'
+
+checksum:
+  name_template: 'checksums.txt'
+
 builds:
   - id: "falcosidekick"
     goos:
-    - linux
+      - linux
     goarch:
-    - amd64
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - '7'
     asmflags:
       - all=-trimpath={{.Env.GOPATH}}
     gcflags:
       - all=-trimpath={{.Env.GOPATH}}
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     binary: falcosidekick
 
 dockers:
   - goos: linux
     goarch: amd64
     dockerfile: Dockerfile
+    use: buildx
     image_templates:
-      - "falcosecurity/falcosidekick:stable"
-      - "falcosecurity/falcosidekick:{{ .Version }}"
-      - "public.ecr.aws/falcosecurity/falcosidekick:stable"
-      - "public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}"
+      - "falcosecurity/falcosidekick:stable-amd64"
+      - "falcosecurity/falcosidekick:{{ .Version }}-amd64"
+      - "public.ecr.aws/falcosecurity/falcosidekick:stable-amd64"
+      - "public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}-amd64"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/amd64"
     extra_files:
-      - outputs
-      - types
-      - config.go
-      - handlers.go
-      - main.go
-      - stats_prometheus.go
-      - stats.go
-      - go.mod
-      - go.sum
-      - Makefile
       - LICENSE
+
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: buildx
+    image_templates:
+      - "falcosecurity/falcosidekick:stable-arm64"
+      - "falcosecurity/falcosidekick:{{ .Version }}-arm64"
+      - "public.ecr.aws/falcosecurity/falcosidekick:stable-arm64"
+      - "public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - LICENSE
+
+  - goos: linux
+    goarch: arm
+    goarm: '7'
+    dockerfile: Dockerfile
+    use: buildx
+    image_templates:
+      - "falcosecurity/falcosidekick:stable-armv7"
+      - "falcosecurity/falcosidekick:{{ .Version }}-armv7"
+      - "public.ecr.aws/falcosecurity/falcosidekick:stable-armv7"
+      - "public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}-armv7"
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--platform=linux/arm/v7"
+    extra_files:
+      - LICENSE
+
+docker_manifests:
+- name_template: 'falcosecurity/falcosidekick:stable'
+  image_templates:
+  - 'falcosecurity/falcosidekick:stable-amd64'
+  - 'falcosecurity/falcosidekick:stable-arm64'
+  - 'falcosecurity/falcosidekick:stable-armv7'
+- name_template: 'falcosecurity/falcosidekick:{{ .Version }}'
+  image_templates:
+  - 'falcosecurity/falcosidekick:{{ .Version }}-amd64'
+  - 'falcosecurity/falcosidekick:{{ .Version }}-arm64'
+  - 'falcosecurity/falcosidekick:{{ .Version }}-armv7'
+- name_template: 'public.ecr.aws/falcosecurity/falcosidekick:stable'
+  image_templates:
+  - 'public.ecr.aws/falcosecurity/falcosidekick:stable-amd64'
+  - 'public.ecr.aws/falcosecurity/falcosidekick:stable-arm64'
+  - 'public.ecr.aws/falcosecurity/falcosidekick:stable-armv7'
+- name_template: 'public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}'
+  image_templates:
+  - 'public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}-amd64'
+  - 'public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}-arm64'
+  - 'public.ecr.aws/falcosecurity/falcosidekick:{{ .Version }}-armv7'
 
 release:
   github:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: falcosidekick
 
 snapshot:
-  name_template: '{{ incpatch .Version }}-next'
+  name_template: 'latest'
 
 checksum:
   name_template: 'checksums.txt'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.16-buster
 ARG BASE_IMAGE=alpine:3.12
-
-FROM ${BUILDER_IMAGE} AS build-stage
-
-ENV CGO_ENABLED=0
-
-WORKDIR /src
-COPY . .
-
-RUN go mod download
-RUN make falcosidekick
-
 # Final Docker image
 FROM ${BASE_IMAGE} AS final-stage
 LABEL MAINTAINER "Thomas Labarussias <issif+falcosidekick@gadz.org>"
@@ -24,8 +12,8 @@ RUN addgroup -S falcosidekick && adduser -u 1234 -S falcosidekick -G falcosideki
 USER 1234
 
 WORKDIR ${HOME}/app
-COPY --from=build-stage /src/LICENSE .
-COPY --from=build-stage /src/falcosidekick .
+COPY LICENSE .
+COPY falcosidekick .
 
 EXPOSE 2801
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,12 @@ GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 falcosidekick:
 	$(GO) build -gcflags all=-trimpath=/src -asmflags all=-trimpath=/src -a -installsuffix cgo -o $@ .
 
+.PHONY: falcosidekick-linux-amd64
+falcosidekick-linux-amd64:
+	GOOS=linux GOARCH=amd64 $(GO) build -gcflags all=-trimpath=/src -asmflags all=-trimpath=/src -a -installsuffix cgo -o falcosidekick .
+
 .PHONY: build-image
-build-image:
+build-image: falcosidekick-linux-amd64
 	$(DOCKER) build . -t falcosecurity/falcosidekick:latest
 
 ## --------------------------------------


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

- Add targets for arm/v7 and arm64 for both binaries and images
- Changed the dockerfile to use the binary we already built in the goreleaser definition, so we don't need to rebuild that again.

- added the build ci pipelines to use goreleaser to build the images as well


tested both arm and arm64 and seems to work fine

/assign  @Issif @leogr

```
  • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • building binaries
      • building                  binary=/home/circleci/project/falcosidekick/dist/falcosidekick_linux_arm_7/falcosidekick
      • building                  binary=/home/circleci/project/falcosidekick/dist/falcosidekick_linux_amd64/falcosidekick
      • building                  binary=/home/circleci/project/falcosidekick/dist/falcosidekick_linux_arm64/falcosidekick
   • archives
      • creating                  archive=dist/falcosidekick_2.16.1-next_linux_arm64.tar.gz
      • creating                  archive=dist/falcosidekick_2.16.1-next_linux_armv7.tar.gz
      • creating                  archive=dist/falcosidekick_2.16.1-next_linux_amd64.tar.gz
   • calculating checksums
      • checksumming              file=falcosidekick_2.16.1-next_linux_amd64.tar.gz
      • checksumming              file=falcosidekick_2.16.1-next_linux_armv7.tar.gz
      • checksumming              file=falcosidekick_2.16.1-next_linux_arm64.tar.gz
   • docker images
      • building docker image     image=falcosecurity/falcosidekick:stable-armv7
      • building docker image     image=falcosecurity/falcosidekick:stable-amd64
      • building docker image     image=falcosecurity/falcosidekick:stable-arm64


circleci@ip-172-28-95-234:~/project/falcosidekick$ docker images
REPOSITORY                                   TAG                 IMAGE ID       CREATED          SIZE
falcosecurity/falcosidekick                  2.16.1-next-arm64   e69d808d5a79   22 seconds ago   46.2MB
falcosecurity/falcosidekick                  stable-arm64        e69d808d5a79   22 seconds ago   46.2MB
public.ecr.aws/falcosecurity/falcosidekick   2.16.1-next-arm64   e69d808d5a79   22 seconds ago   46.2MB
public.ecr.aws/falcosecurity/falcosidekick   stable-arm64        e69d808d5a79   22 seconds ago   46.2MB
falcosecurity/falcosidekick                  2.16.1-next-armv7   27074ae6be1e   24 seconds ago   40MB
falcosecurity/falcosidekick                  stable-armv7        27074ae6be1e   24 seconds ago   40MB
public.ecr.aws/falcosecurity/falcosidekick   2.16.1-next-armv7   27074ae6be1e   24 seconds ago   40MB
public.ecr.aws/falcosecurity/falcosidekick   stable-armv7        27074ae6be1e   24 seconds ago   40MB
falcosecurity/falcosidekick                  2.16.1-next-amd64   c5fc8689377d   27 seconds ago   49.3MB
falcosecurity/falcosidekick                  stable-amd64        c5fc8689377d   27 seconds ago   49.3MB
public.ecr.aws/falcosecurity/falcosidekick   2.16.1-next-amd64   c5fc8689377d   27 seconds ago   49.3MB
public.ecr.aws/falcosecurity/falcosidekick   stable-amd64        c5fc8689377d   27 seconds ago   49.3MB
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/falcosecurity/falcosidekick/issues/285

**Special notes for your reviewer**:


