### PR TITLE
add version to falcosidekick

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,9 @@ jobs:
     - run:
         command: |
           export PATH=$PATH:/usr/local/goreleaser
-          goreleaser --snapshot --rm-dist
+          make goreleaser-snapshot
           docker images
-          docker run falcosecurity/falcosidekick:latest-amd64 --help
+          docker run falcosecurity/falcosidekick:latest-amd64 --version
 
   build-push-main:
     executor:
@@ -92,8 +92,8 @@ jobs:
     - run:
         command: |
           export PATH=$PATH:/usr/local/goreleaser
-          goreleaser --snapshot --rm-dist
-          docker run falcosecurity/falcosidekick:latest-amd64 --help
+          make goreleaser-snapshot
+          docker run falcosecurity/falcosidekick:latest-amd64 --version
     - run:
         command: |
           echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
@@ -118,7 +118,7 @@ jobs:
         command: |
           export PATH=$PATH:/usr/local/goreleaser
           goreleaser --snapshot --rm-dist
-          docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --help
+          docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --version
     - run:
         command: |
           aws ecr-public get-login-password --region us-east-1 | \
@@ -152,7 +152,7 @@ jobs:
             docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
     - run:
         name: Release
-        command: goreleaser release --rm-dist
+        command: make goreleaser
 
 workflows:
   main:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,8 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
     binary: falcosidekick
 
 dockers:

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -24,7 +25,14 @@ func getConfig() *types.Configuration {
 	}
 
 	configFile := kingpin.Flag("config-file", "config file").Short('c').ExistingFile()
+	version := kingpin.Flag("version", "falcosidekick version").Short('v').Bool()
 	kingpin.Parse()
+
+	if *version != false {
+		v := GetVersionInfo()
+		fmt.Println(v.String())
+		os.Exit(0)
+	}
 
 	v := viper.New()
 	v.SetDefault("ListenAddress", "")

--- a/main.go
+++ b/main.go
@@ -461,7 +461,6 @@ func init() {
 		} else {
 			outputs.EnabledOutputs = append(outputs.EnabledOutputs, outputName)
 		}
-		log.Printf("[INFO]  : Enabled Outputs : %s\n", outputs.EnabledOutputs)
 	}
 
 	if config.Yandex.S3.Bucket != "" {
@@ -488,6 +487,7 @@ func init() {
 		}
 	}
 
+	log.Printf("[INFO]  : Falco Sidekick version: %s\n", GetVersionInfo().GitVersion)
 	log.Printf("[INFO]  : Enabled Outputs : %s\n", outputs.EnabledOutputs)
 
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+)
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags (e.g. via Makefile).
+var (
+	// Output of "git describe". The prerequisite is that the branch should be
+	// tagged using the correct versioning strategy.
+	GitVersion = "devel"
+	// SHA1 from git, output of $(git rev-parse HEAD)
+	gitCommit = "unknown"
+	// State of git tree, either "clean" or "dirty"
+	gitTreeState = "unknown"
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate = "unknown"
+)
+
+type Info struct {
+	GitVersion   string
+	GitCommit    string
+	GitTreeState string
+	BuildDate    string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func GetVersionInfo() Info {
+	return Info{
+		GitVersion:   GitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns the string representation of the version info
+func (i *Info) String() string {
+	b := strings.Builder{}
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+
+	w.Flush()
+	return b.String()
+}
+
+// JSONString returns the JSON representation of the version info
+func (i *Info) JSONString() (string, error) {
+	b, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

add version flag to falcosidekick, this will help to troubleshoot any possible community issues, because we can ask for the version that happened

```
$ docker run falcosecurity/falcosidekick:stable-amd64 --version
GitVersion:    2.24.0-17-g420e03e-dirty
GitCommit:     420e03e47c3b0e94bb901eafb5ee01786c8a537e
GitTreeState:  dirty
BuildDate:     '2021-12-05T14:58:21Z'
GoVersion:     go1.17.3
Compiler:      gc
Platform:      linux/amd64
```

it will log as well when falcosidekick starts

```
$ ./falcosidekick -c config.yaml
2021/12/05 16:06:55 [INFO]  : Falco Sidekick version: 2.24.0-11-gcefd9b8-dirty
2021/12/05 16:06:55 [INFO]  : Enabled Outputs : [Opsgenie]
2021/12/05 16:06:55 [INFO]  : Falco Sidekick is up and listening on :2801
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


