### PR TITLE
ci: set the no outpout timeout for the circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
     - run: *setup_docker_multiarch
     - run: *install_goreleaser
     - run:
+        no_output_timeout: 30m
         command: |
           export PATH=$PATH:/usr/local/goreleaser
           make goreleaser-snapshot
@@ -90,11 +91,14 @@ jobs:
     - run: *setup_docker_multiarch
     - run: *install_goreleaser
     - run:
+        no_output_timeout: 30m
         command: |
           export PATH=$PATH:/usr/local/goreleaser
           make goreleaser-snapshot
           docker run falcosecurity/falcosidekick:latest-amd64 --version
     - run:
+        name: Push image to Dockerhub
+        no_output_timeout: 30m
         command: |
           echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
           docker push falcosecurity/falcosidekick:latest-amd64
@@ -115,11 +119,14 @@ jobs:
     - run: *install_goreleaser
     - run: *install_awscli
     - run:
+        no_output_timeout: 30m
         command: |
           export PATH=$PATH:/usr/local/goreleaser
           goreleaser --snapshot --rm-dist
           docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --version
     - run:
+        name: Push image to AWS ECR
+        no_output_timeout: 30m
         command: |
           aws ecr-public get-login-password --region us-east-1 | \
             docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
@@ -152,6 +159,7 @@ jobs:
             docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
     - run:
         name: Release
+        no_output_timeout: 30m
         command: make goreleaser
 
 workflows:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**Any specific area of the project related to this PR?**

/area build


**What this PR does / why we need it**:

we are getting this error in the circleci jobs `Too long with no output (exceeded 10m0s)` this is because the job is taking more time to build and that did not output anything during the build so circleci understand that is stuck.

increasing the no output timeout fix the issue



**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


