### PR TITLE
add archive and s3 publish configs to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,3 +112,13 @@ docker_manifests:
 release:
   github:
   prerelease: auto
+archives:
+  - id: falcosidekick-archive
+    builds:
+    - falcosidekick
+blobs:
+  - provider: s3
+    bucket: falco-distribution
+    folder: /packages/bin/noarch/
+    ids:
+    - falcosidekick-archive

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,6 +119,6 @@ archives:
 blobs:
   - provider: s3
     bucket: falco-distribution
-    folder: /packages/bin/noarch/
+    folder: /packages/bin/{{ .Arch }}/
     ids:
     - falcosidekick-archive


### PR DESCRIPTION
Signed-off-by: Matan Monitz <mmonitz@gmail.com>


**What type of PR is this?**

/kind feature
/area build

**What this PR does / why we need it**:

This PR introduces an archive and blob configs to goreleaser for falcosidekick
currently falcosidekick build config only packages docker images, but some use cases require running sidekick binary on a host with no docker or other container runtime. this will PR will make the built binary archive available on the project S3 bucket for download, similarly to the falco binary distribution

**Which issue(s) this PR fixes**:

Fixes #306 

**Special notes for your reviewer**:
hope this doesn't break the build :)
/cc @Issif 

