### PR TITLE
feat(loki): Add tenant for loki

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ loki:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Loki output is enabled
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # tenant: "" # Add the tenant header if needed. Enabled if not empty
 
 stan:
   # hostport: "" # nats://{domain or ip}:{port}, if not empty, STAN output is enabled
@@ -602,6 +603,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
 - **LOKI_CHECKCERT** : check if ssl certificate of the output is valid (default:
   `true`)
+- **LOKI_TENANT** : Loki tenant, if not `empty`, Loki tenant is _enabled_
 - **NATS_HOSTPORT** : NATS "nats://host:port", if not `empty`, NATS is _enabled_
 - **NATS_MINIMUMPRIORITY** : minimum priority of event for using this output,
   order is

--- a/config.go
+++ b/config.go
@@ -117,6 +117,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Loki.MinimumPriority", "")
 	v.SetDefault("Loki.MutualTLS", false)
 	v.SetDefault("Loki.CheckCert", true)
+	v.SetDefault("Loki.Tenant", "")
 
 	v.SetDefault("AWS.AccessKeyID", "")
 	v.SetDefault("AWS.SecretAccessKey", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -80,6 +80,7 @@ loki:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # tenant: "" # Add the tenant header if needed. Tenant header is enabled only if not empty
 
 nats:
   # hostport: "" # nats://{domain or ip}:{port}, if not empty, NATS output is enabled
@@ -280,4 +281,3 @@ policyreport:
   failthreshold: 4 # events with priority above this threshold are mapped to fail in PolicyReport Summary and lower that those are mapped to warn (default=4)
   maxevents: 1000 # the max number of events per report(default: 1000)
   prunebypriority: false # if true; the events with lowest severity are pruned first, in FIFO order (default: false)
-  

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -51,6 +51,9 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 func (c *Client) LokiPost(falcopayload types.FalcoPayload) {
 	c.Stats.Loki.Add(Total, 1)
 	c.ContentType = LokiContentType
+	if c.Config.Loki.Tenant != "" {
+		c.AddHeader("X-Scope-OrgID", c.Config.Loki.Tenant)
+	}
 
 	err := c.Post(newLokiPayload(falcopayload, c.Config))
 	if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -190,6 +190,7 @@ type lokiOutputConfig struct {
 	MinimumPriority string
 	CheckCert       bool
 	MutualTLS       bool
+	Tenant          string
 }
 
 type natsOutputConfig struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area config


**What this PR does / why we need it**:

This change allows to add a "tenant header" in the configuration file at the
loki.tenant key.

Why :
Loki is able to differentiate logs coming from a specific tenant , but
it is needed to add a header in the configuration :


https://grafana.com/docs/loki/latest/operations/multi-tenancy/

This change does not bring any breaking changes.


Signed-off-by: Julien Godin <julien.godin@camptocamp.com>