### PR TITLE
feat(loki) : upgrade loki endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ loki:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # tenant: "" # Add the tenant header if needed. Enabled if not empty
+  # endpoint: "/api/prom/push" # The endpoint URL path, default is "/api/prom/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
 
 stan:
   # hostport: "" # nats://{domain or ip}:{port}, if not empty, STAN output is enabled
@@ -604,6 +605,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **LOKI_CHECKCERT** : check if ssl certificate of the output is valid (default:
   `true`)
 - **LOKI_TENANT** : Loki tenant, if not `empty`, Loki tenant is _enabled_
+- **LOKI_ENDPOINT** : Loki endpoint URL path, default is "/api/prom/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
 - **NATS_HOSTPORT** : NATS "nats://host:port", if not `empty`, NATS is _enabled_
 - **NATS_MINIMUMPRIORITY** : minimum priority of event for using this output,
   order is

--- a/config.go
+++ b/config.go
@@ -118,6 +118,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Loki.MutualTLS", false)
 	v.SetDefault("Loki.CheckCert", true)
 	v.SetDefault("Loki.Tenant", "")
+	v.SetDefault("Loki.Endpoint", "/api/prom/push")
 
 	v.SetDefault("AWS.AccessKeyID", "")
 	v.SetDefault("AWS.SecretAccessKey", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -81,6 +81,7 @@ loki:
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # tenant: "" # Add the tenant header if needed. Tenant header is enabled only if not empty
+  # endpoint: "/api/prom/push" # The endpoint URL path, default is "/api/prom/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
 
 nats:
   # hostport: "" # nats://{domain or ip}:{port}, if not empty, NATS output is enabled

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func init() {
 
 	if config.Loki.HostPort != "" {
 		var err error
-		lokiClient, err = outputs.NewClient("Loki", config.Loki.HostPort+"/api/prom/push", config.Loki.MutualTLS, config.Loki.CheckCert, config, stats, promStats, statsdClient, dogstatsdClient)
+		lokiClient, err = outputs.NewClient("Loki", config.Loki.HostPort+config.Loki.Endpoint, config.Loki.MutualTLS, config.Loki.CheckCert, config, stats, promStats, statsdClient, dogstatsdClient)
 		if err != nil {
 			config.Loki.HostPort = ""
 		} else {

--- a/types/types.go
+++ b/types/types.go
@@ -191,6 +191,7 @@ type lokiOutputConfig struct {
 	CheckCert       bool
 	MutualTLS       bool
 	Tenant          string
+	Endpoint        string
 }
 
 type natsOutputConfig struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecation

**Any specific area of the project related to this PR?**

/area outputs

**Why** :

According to the documentation :

https://grafana.com/docs/loki/latest/api/#post-apiprompush

`/api/prom/push` is deprecated and is replaced by `/loki/api/v1/push`

**Any specific area of the project related to this PR?** :

standard api upgrade

This change can break older unspecified loki versions

Signed-off-by: Julien Godin <julien.godin@camptocamp.com>