### PR TITLE
add clustername in outputPayLoad

### DIFF
--- a/config.go
+++ b/config.go
@@ -314,6 +314,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Syslog.Port", "")
 	v.SetDefault("Syslog.Protocol", "")
 	v.SetDefault("Syslog.MinimumPriority", "")
+	v.SetDefault("Syslog.ClusterName", "")
 
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -271,6 +271,15 @@ grafana:
 webui:
   url: "" # WebUI URL, if not empty, WebUI output is enabled
 
+
+syslog:
+  host: ""    # host: "" # Syslog host, if not empty, Syslog output is enabled
+  port: ""    # port: "" # Syslog endpoint port number
+  protocol: ""    # protocol: "" # Syslog transport protocol. It can be either "tcp" or "udp"
+  minimumpriority: "" # minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
+  clustername: "" # clustername: "" # the cluster name
+
+
 fission:
   function: "" # Name of Fission function, if not empty, Fission is enabled
   routernamespace: "fission" # Namespace of Fission Router, "fission" (default)

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -277,7 +277,7 @@ syslog:
   port: ""    # port: "" # Syslog endpoint port number
   protocol: ""    # protocol: "" # Syslog transport protocol. It can be either "tcp" or "udp"
   minimumpriority: "" # minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-  clustername: "" # clustername: "" # the cluster name
+  clustername: "" # clustername: "" # The cluster name
 
 
 fission:

--- a/outputs/syslog.go
+++ b/outputs/syslog.go
@@ -3,11 +3,12 @@ package outputs
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-go/statsd"
-	"github.com/falcosecurity/falcosidekick/types"
 	"log"
 	"log/syslog"
 	"strings"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/falcosecurity/falcosidekick/types"
 )
 
 func NewSyslogClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
@@ -33,6 +34,8 @@ func isValidProtocolString(protocol string) bool {
 func (c *Client) SyslogPost(falcopayload types.FalcoPayload) {
 	c.Stats.Syslog.Add(Total, 1)
 	endpoint := fmt.Sprintf("%s:%s", c.Config.Syslog.Host, c.Config.Syslog.Port)
+
+	falcopayload.OutputFields["clustername"] = c.Config.Syslog.ClusterName
 
 	var priority syslog.Priority
 	switch falcopayload.Priority {

--- a/types/types.go
+++ b/types/types.go
@@ -449,11 +449,13 @@ type YandexS3Config struct {
 // Host: the remote syslog host. It can be either an IP address or a domain.
 // Port: the remote port address. Ex: 514.
 // Protocol: the type of transfer protocol to use. It should be either "tcp" or "udp".
+// ClusterName : the name is cluster
 type SyslogConfig struct {
 	Host            string
 	Port            string
 	Protocol        string
 	MinimumPriority string
+	ClusterName     string
 }
 
 // Statistics is a struct to store stastics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area outputs


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

[https://github.com/falcosecurity/falcosidekick/issues/319](url)

Add Clustername for module Syslog with this we can recognize from which cluster it comes.
It is very necessary to know from which cluster the information is received.

`"output_fields":{"clustername":"test"}`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


