### PR TITLE
Allow EndsAt field to be specified for alertmanager alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ alertmanager:
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
-
+  # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
@@ -573,6 +573,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   `true`)
 - **ALERTMANAGER_ENDPOINT** : alertmanager endpoint on which falcosidekick posts alerts, choice is:
   `"/api/v1/alerts" or "/api/v2/alerts" , default is "/api/v1/alerts"`
+- **ALERTMANAGER_EXPIRESAFTER** : if set to a non-zero value, alert expires after that time in seconds (default: 0)
 - **ELASTICSEARCH_HOSTPORT** : Elasticsearch http://host:port, if not `empty`,
   Elasticsearch is _enabled_
 - **ELASTICSEARCH_INDEX** : Elasticsearch index (default: falco)

--- a/config.go
+++ b/config.go
@@ -94,6 +94,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Alertmanager.MutualTls", false)
 	v.SetDefault("Alertmanager.CheckCert", true)
 	v.SetDefault("Alertmanager.Endpoint", "/api/v1/alerts")
+	v.SetDefault("Alertmanager.ExpiresAfter", 0)
 
 	v.SetDefault("Elasticsearch.HostPort", "")
 	v.SetDefault("Elasticsearch.Index", "falco")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -54,6 +54,7 @@ alertmanager:
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
+  # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
@@ -122,7 +123,6 @@ aws:
   kinesis:
     # streamname: "" # AWS Kinesis Stream Name, if not empty, Kinesis output is enabled
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-
 
 smtp:
   # hostport: "" # host:port address of SMTP server, if not empty, SMTP output is enabled
@@ -281,8 +281,8 @@ fission:
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
 
 policyreport:
-  enabled: false  # if true policyreport output is enabled
-  kubeconfig: "~/.kube/config"  # Kubeconfig file to use (only if falcosidekick is running outside the cluster)
+  enabled: false # if true policyreport output is enabled
+  kubeconfig: "~/.kube/config" # Kubeconfig file to use (only if falcosidekick is running outside the cluster)
   failthreshold: 4 # events with priority above this threshold are mapped to fail in PolicyReport Summary and lower that those are mapped to warn (default=4)
   maxevents: 1000 # the max number of events per report(default: 1000)
   prunebypriority: false # if true; the events with lowest severity are pruned first, in FIFO order (default: false)

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -16,7 +16,7 @@ type alertmanagerPayload struct {
 	EndsAt      time.Time         `json:"endsAt,omitempty"`
 }
 
-func (c *Client) newAlertmanagerPayload(falcopayload types.FalcoPayload) []alertmanagerPayload {
+func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Configuration) []alertmanagerPayload {
 	var amPayload alertmanagerPayload
 	amPayload.Labels = make(map[string]string)
 	amPayload.Annotations = make(map[string]string)
@@ -79,8 +79,8 @@ func (c *Client) newAlertmanagerPayload(falcopayload types.FalcoPayload) []alert
 
 	amPayload.Annotations["info"] = falcopayload.Output
 	amPayload.Annotations["summary"] = falcopayload.Rule
-	if c.Config.Alertmanager.ExpiresAfter != 0 {
-		amPayload.EndsAt = falcopayload.Time.Add(time.Duration(c.Config.Alertmanager.ExpiresAfter) * time.Second)
+	if config.Alertmanager.ExpiresAfter != 0 {
+		amPayload.EndsAt = falcopayload.Time.Add(time.Duration(config.Alertmanager.ExpiresAfter) * time.Second)
 	}
 
 	var a []alertmanagerPayload
@@ -94,7 +94,7 @@ func (c *Client) newAlertmanagerPayload(falcopayload types.FalcoPayload) []alert
 func (c *Client) AlertmanagerPost(falcopayload types.FalcoPayload) {
 	c.Stats.Alertmanager.Add(Total, 1)
 
-	err := c.Post(c.newAlertmanagerPayload(falcopayload))
+	err := c.Post(newAlertmanagerPayload(falcopayload, c.Config))
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:alertmanager", "status:error"})
 		c.Stats.Alertmanager.Add(Error, 1)

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -18,7 +18,12 @@ func TestNewAlertmanagerPayloadO(t *testing.T) {
 	d.UseNumber()
 	err := d.Decode(&f) //have to decode it the way newFalcoPayload does
 	require.Nil(t, err)
-	s, err := json.Marshal(newAlertmanagerPayload(f))
+
+	config := &types.Configuration{
+		Alertmanager: types.AlertmanagerOutputConfig{},
+	}
+
+	s, err := json.Marshal(newAlertmanagerPayload(f, config))
 	require.Nil(t, err)
 
 	var o1, o2 []alertmanagerPayload

--- a/types/types.go
+++ b/types/types.go
@@ -163,6 +163,7 @@ type alertmanagerOutputConfig struct {
 	CheckCert       bool
 	MutualTLS       bool
 	Endpoint        string
+	ExpiresAfter    int
 }
 
 type elasticsearchOutputConfig struct {

--- a/types/types.go
+++ b/types/types.go
@@ -34,7 +34,7 @@ type Configuration struct {
 	Teams              teamsOutputConfig
 	Datadog            datadogOutputConfig
 	Discord            DiscordOutputConfig
-	Alertmanager       alertmanagerOutputConfig
+	Alertmanager       AlertmanagerOutputConfig
 	Elasticsearch      elasticsearchOutputConfig
 	Influxdb           influxdbOutputConfig
 	Loki               lokiOutputConfig
@@ -157,7 +157,7 @@ type DiscordOutputConfig struct {
 	MutualTLS       bool
 }
 
-type alertmanagerOutputConfig struct {
+type AlertmanagerOutputConfig struct {
 	HostPort        string
 	MinimumPriority string
 	CheckCert       bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area config
/area outputs


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Allows the EndsAt alert parameter to be configured

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #322

**Special notes for your reviewer**: N/A


