### PR TITLE
fix Panic for prometheus metrics when CustomFields are set

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ func getConfig() *types.Configuration {
 	version := kingpin.Flag("version", "falcosidekick version").Short('v').Bool()
 	kingpin.Parse()
 
-	if *version != false {
+	if *version {
 		v := GetVersionInfo()
 		fmt.Println(v.String())
 		os.Exit(0)
@@ -334,7 +334,7 @@ func getConfig() *types.Configuration {
 		}
 	}
 
-	v.GetStringMapString("customfields")
+	v.GetStringMapString("Customfields")
 	v.GetStringMapString("Webhook.CustomHeaders")
 	v.GetStringMapString("CloudEvents.Extensions")
 	if err := v.Unmarshal(c); err != nil {
@@ -352,8 +352,8 @@ func getConfig() *types.Configuration {
 	}
 
 	if value, present := os.LookupEnv("WEBHOOK_CUSTOMHEADERS"); present {
-		customfields := strings.Split(value, ",")
-		for _, label := range customfields {
+		customheaders := strings.Split(value, ",")
+		for _, label := range customheaders {
 			tagkeys := strings.Split(label, ":")
 			if len(tagkeys) == 2 {
 				c.Webhook.CustomHeaders[tagkeys[0]] = tagkeys[1]
@@ -362,8 +362,8 @@ func getConfig() *types.Configuration {
 	}
 
 	if value, present := os.LookupEnv("CLOUDEVENTS_EXTENSIONS"); present {
-		customfields := strings.Split(value, ",")
-		for _, label := range customfields {
+		extensions := strings.Split(value, ",")
+		for _, label := range extensions {
 			tagkeys := strings.Split(label, ":")
 			if len(tagkeys) == 2 {
 				c.CloudEvents.Extensions[tagkeys[0]] = tagkeys[1]
@@ -384,7 +384,7 @@ func getConfig() *types.Configuration {
 	}
 
 	if c.Prometheus.ExtraLabels != "" {
-		c.Prometheus.ExtraLabelsList = strings.Split(strings.ReplaceAll(c.Loki.ExtraLabels, " ", ""), ",")
+		c.Prometheus.ExtraLabelsList = strings.Split(strings.ReplaceAll(c.Prometheus.ExtraLabels, " ", ""), ",")
 	}
 
 	c.Slack.MinimumPriority = checkPriority(c.Slack.MinimumPriority)

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -83,7 +83,7 @@ loki:
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # tenant: "" # Add the tenant header if needed. Tenant header is enabled only if not empty
   # endpoint: "/api/prom/push" # The endpoint URL path, default is "/api/prom/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
-  # extralabels: "" # comma separated list of fields to use as labels additionnally to rule, source, priority, tags and custom_fields
+  # extralabels: "" # comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields
 
 nats:
   # hostport: "" # nats://{domain or ip}:{port}, if not empty, NATS output is enabled
@@ -135,7 +135,7 @@ smtp:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 prometheus:
-  # extralabels: "" # comma separated list of fields to use as labels additionnally to rule, source, priority, tags and custom_fields
+  # extralabels: "" # comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields
 
 statsd:
   forwarder: "" # The address for the StatsD forwarder, in the form "host:port", if not empty StatsD is enabled

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -58,6 +59,8 @@ var (
 	config                        *types.Configuration
 	stats                         *types.Statistics
 	promStats                     *types.PromStatistics
+
+	regPromLabels *regexp.Regexp
 )
 
 func init() {
@@ -68,6 +71,9 @@ func init() {
 	if testing {
 		return
 	}
+
+	regPromLabels, _ = regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+
 	config = getConfig()
 	stats = getInitStats()
 	promStats = getInitPromStats(config)
@@ -434,7 +440,7 @@ func init() {
 			outputs.EnabledOutputs = append(outputs.EnabledOutputs, "WebUI")
 		}
 	}
-	if config.PolicyReport.Enabled == true {
+	if config.PolicyReport.Enabled {
 		var err error
 		policyReportClient, err = outputs.NewPolicyReportClient(config, stats, promStats, statsdClient, dogstatsdClient)
 		if err != nil {

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -33,8 +33,15 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 	for i, j := range falcopayload.OutputFields {
 		switch v := j.(type) {
 		case string:
-			if contains(config.Loki.ExtraLabelsList, i) {
-				s += strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(i, ".", ""), "]", ""), "[", "") + "=\"" + strings.ReplaceAll(v, "\"", "") + "\","
+			for k := range config.Customfields {
+				if i == k {
+					s += strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(i, ".", ""), "]", ""), "[", "") + "=\"" + strings.ReplaceAll(v, "\"", "") + "\","
+				}
+			}
+			for _, k := range config.Loki.ExtraLabelsList {
+				if i == k {
+					s += strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(i, ".", ""), "]", ""), "[", "") + "=\"" + strings.ReplaceAll(v, "\"", "") + "\","
+				}
 			}
 		default:
 			continue
@@ -47,9 +54,9 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 
 	s += "rule=\"" + falcopayload.Rule + "\","
 	s += "source=\"" + falcopayload.Source + "\","
-	s += "priority=\"" + falcopayload.Priority.String() + "\","
+	s += "priority=\"" + falcopayload.Priority.String() + "\""
 
-	ls.Labels = "{" + s[:len(s)-1] + "}"
+	ls.Labels = "{" + s + "}"
 
 	return lokiPayload{Streams: []lokiStream{ls}}
 }

--- a/outputs/utils.go
+++ b/outputs/utils.go
@@ -15,12 +15,3 @@ func getSortedStringKeys(m map[string]interface{}) []string {
 	sort.Strings(keys)
 	return keys
 }
-
-func contains(slice []string, str string) bool {
-	for _, i := range slice {
-		if i == str {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
… labels for Loki for CustomFields and ExtraFields

Signed-off-by: Issif <issif+github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

#330 

> Uncomment one (or more) `/area <>` lines:

> /area build

/area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix the Panic for Prometheus when custom_fields are set
Allow to specify which fields to use as extra labels for Prometheus and Loki
Some lints

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


