### PR TITLE
Adding Yandex Data Streams support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ It works as a single endpoint for as many as you want `Falco` instances :
 - [**Kafka Rest Proxy**](https://docs.confluent.io/platform/current/kafka-rest/index.html)
 - [**RabbitMQ**](https://www.rabbitmq.com/)
 - [**Azure Event Hubs**](https://azure.microsoft.com/en-in/services/event-hubs/)
+- [**Yandex Data Streams**](https://cloud.yandex.com/en/docs/data-streams/)
 
 ### Email
 
@@ -454,10 +455,14 @@ yandex:
   # secretaccesskey: "" # yandex secret access key
   # region: "" # yandex storage region (default: ru-central-1)
   s3:
-    # endpoint: "" yandex storage endpoint (default: https://storage.yandexcloud.net)
+    # endpoint: "" # yandex storage endpoint (default: https://storage.yandexcloud.net)
     # bucket: "falcosidekick" # Yandex storage, bucket name
     # prefix: "" # name of prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json
-    # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|erro
+    # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
+  datastreams:
+    # endpoint: "" # Yandex Data Streams endpoint (default: https://yds.serverless.yandexcloud.net)
+    # streamname: "" # stream name in format /${region}/${folder_id}/${ydb_id}/${stream_name}
+    # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
 
 syslog:
   # host: "" # Syslog host, if not empty, Syslog output is enabled
@@ -851,7 +856,10 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **YANDEX_S3_ENDPOINT**: Yandex storage endpoint (default: https://storage.yandexcloud.net)
 - **YANDEX_S3_BUCKET**: Yandex storage, bucket name
 - **YANDEX_S3_PREFIX**: name of prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json
-- **YANDEX_S3_MINIMUMPRIORITY**: # minimum priority of event for using this output, order is emergency|alert|critical|erro
+- **YANDEX_S3_MINIMUMPRIORITY**: # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
+- **YANDEX_DATASTREAMS_ENDPOINT**: Yandex Data Streams endpoint (default: https://yds.serverless.yandexcloud.net)
+- **YANDEX_DATASTREAMS_STREAMNAME**: Stream name in format /${region}/${folder_id}/${ydb_id}/${stream_name}
+- **YANDEX_DATASTREAMS_MINIMUMPRIORITY**: # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
 - **SYSLOG_HOST**: Syslog Host, if not empty, Syslog output is enabled
 - **SYSLOG_PORT**: Syslog endpoint port number
 - **SYSLOG_PROTOCOL**: Syslog transport protocol. It can be either "tcp" or "udp"

--- a/config.go
+++ b/config.go
@@ -309,10 +309,15 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Yandex.AccessKeyID", "")
 	v.SetDefault("Yandex.SecretAccessKey", "")
 	v.SetDefault("Yandex.Region", "ru-central1")
+
 	v.SetDefault("Yandex.S3.Endpoint", "https://storage.yandexcloud.net")
 	v.SetDefault("Yandex.S3.Bucket", "")
 	v.SetDefault("Yandex.S3.Prefix", "falco")
 	v.SetDefault("Yamdex.S3.MinimumPriority", "")
+
+	v.SetDefault("Yandex.DataStreams.Endpoint", "https://yds.serverless.yandexcloud.net")
+	v.SetDefault("Yandex.DataStreams.StreamName", "")
+	v.SetDefault("Yandex.DataStreams.MinimumPriority", "")
 
 	v.SetDefault("Syslog.Host", "")
 	v.SetDefault("Syslog.Port", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -290,3 +290,17 @@ policyreport:
   failthreshold: 4 # events with priority above this threshold are mapped to fail in PolicyReport Summary and lower that those are mapped to warn (default=4)
   maxevents: 1000 # the max number of events per report(default: 1000)
   prunebypriority: false # if true; the events with lowest severity are pruned first, in FIFO order (default: false)
+
+yandex:
+  # accesskeyid: "" # yandex access key
+  # secretaccesskey: "" # yandex secret access key
+  # region: "" # yandex storage region (default: ru-central-1)
+  s3:
+    # endpoint: "" # yandex storage endpoint (default: https://storage.yandexcloud.net)
+    # bucket: "falcosidekick" # Yandex storage, bucket name
+    # prefix: "" # name of prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json
+    # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
+  datastreams:
+    # endpoint: "" # Yandex Data Streams endpoint (default: https://yds.serverless.yandexcloud.net)
+    # streamname: "" # stream name in format /${region}/${folder_id}/${ydb_id}/${stream_name}
+    # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug

--- a/handlers.go
+++ b/handlers.go
@@ -302,6 +302,10 @@ func forwardEvent(falcopayload types.FalcoPayload) {
 		go yandexClient.UploadYandexS3(falcopayload)
 	}
 
+	if config.Yandex.DataStreams.StreamName != "" && (falcopayload.Priority >= types.Priority(config.Yandex.DataStreams.MinimumPriority) || falcopayload.Rule == testRule) {
+		go yandexClient.UploadYandexDataStreams(falcopayload)
+	}
+
 	if config.Syslog.Host != "" && (falcopayload.Priority >= types.Priority(config.Syslog.MinimumPriority) || falcopayload.Rule == testRule) {
 		go syslogClient.SyslogPost(falcopayload)
 	}

--- a/main.go
+++ b/main.go
@@ -515,6 +515,19 @@ func init() {
 		}
 	}
 
+	if config.Yandex.DataStreams.StreamName != "" {
+		var err error
+		yandexClient, err = outputs.NewYandexClient(config, stats, promStats, statsdClient, dogstatsdClient)
+		if err != nil {
+			config.Yandex.DataStreams.StreamName = ""
+			log.Printf("[ERROR] : Yandex - %v\n", err)
+		} else {
+			if config.Yandex.DataStreams.StreamName != "" {
+				outputs.EnabledOutputs = append(outputs.EnabledOutputs, "YandexDataStreams")
+			}
+		}
+	}
+
 	if config.Syslog.Host != "" {
 		var err error
 		syslogClient, err = outputs.NewSyslogClient(config, stats, promStats, statsdClient, dogstatsdClient)

--- a/stats.go
+++ b/stats.go
@@ -64,6 +64,7 @@ func getInitStats() *types.Statistics {
 		Fission:           getOutputNewMap("fission"),
 		Grafana:           getOutputNewMap("grafana"),
 		YandexS3:          getOutputNewMap("yandexs3"),
+		YandexDataStreams: getOutputNewMap("yandexdatastreams"),
 		Syslog:            getOutputNewMap("syslog"),
 		PolicyReport:      getOutputNewMap("policyreport"),
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -446,11 +446,17 @@ type YandexOutputConfig struct {
 	SecretAccessKey string
 	Region          string
 	S3              YandexS3Config
+	DataStreams     YandexDataStreamsConfig
 }
 type YandexS3Config struct {
 	Endpoint        string
 	Prefix          string
 	Bucket          string
+	MinimumPriority string
+}
+type YandexDataStreamsConfig struct {
+	Endpoint        string
+	StreamName      string
 	MinimumPriority string
 }
 
@@ -512,6 +518,7 @@ type Statistics struct {
 	Fission           *expvar.Map
 	Grafana           *expvar.Map
 	YandexS3          *expvar.Map
+	YandexDataStreams *expvar.Map
 	Syslog            *expvar.Map
 	Cliq              *expvar.Map
 	PolicyReport      *expvar.Map


### PR DESCRIPTION
Hello. This PR will allow using [Yandex Data Streams](https://cloud.yandex.com/en/docs/data-streams/) for output. Can it be merged, please?