### PR TITLE
Adding back priority label for Alertmanager outputs

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -77,6 +77,7 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 		amPayload.Labels["tags"] = strings.Join(falcopayload.Tags, ",")
 	}
 
+	amPayload.Labels["priority"] = falcopayload.Priority.String()
 	amPayload.Annotations["info"] = falcopayload.Output
 	amPayload.Annotations["summary"] = falcopayload.Rule
 	if config.Alertmanager.ExpiresAfter != 0 {

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewAlertmanagerPayloadO(t *testing.T) {
-	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","proc_tty":"1234","eventsource":"syscalls","rule":"Test rule","source":"falco","tags":"test,example"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
+	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","rule":"Test rule","source":"falco"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
 
 	var f types.FalcoPayload
 	d := json.NewDecoder(strings.NewReader(falcoTestInput))

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewAlertmanagerPayloadO(t *testing.T) {
-	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","rule":"Test rule","source":"falco"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
+	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","eventsource":"syscalls","rule":"Test rule","source":"falco","tags":"test,example"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
 
 	var f types.FalcoPayload
 	d := json.NewDecoder(strings.NewReader(falcoTestInput))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

/area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds back the priority label for alertmanager outputs. Release 2.25.0 was supposed to resolve #276 and add it but priority was replaced with eventsource. 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #339

**Special notes for your reviewer**:


