### PR TITLE
feat(SASL-Auth): Now SMTP output may use any SASL Auth mechanisms 

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,12 @@ aws:
 
 smtp:
   # hostport: "" # host:port address of SMTP server, if not empty, SMTP output is enabled
-  # user: "" # user to access SMTP server
-  # password: "" # password to access SMTP server
+  # authmechanism: "plain" # SASL Mechanisms : plain, oauthbearer, external, anonymous or "" (disable SASL). Default: plain
+  # user: "" # user for Plain Mechanism
+  # password: "" # password for Plain Mechanism
+  # token: "" # OAuthBearer token for OAuthBearer Mechanism
+  # identity: "" # identity string for Plain and External Mechanisms
+  # trace: "" trace string for Anonymous Mechanism
   # from: "" # Sender address (mandatory if SMTP output is enabled)
   # to: "" # comma-separated list of Recipident addresses, can't be empty (mandatory if SMTP output is enabled)
   # outputformat: "" # html (default), text
@@ -687,8 +691,6 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
 - **SMTP_HOSTPORT** : "host:port" address of SMTP server, if not empty, SMTP
   output is _enabled_
-- **SMTP_USER** : user to access SMTP server
-- **SMTP_PASSWORD** : password to access SMTP server
 - **SMTP_FROM** : Sender address (mandatory if SMTP output is enabled)
 - **SMTP_TO** : comma-separated list of Recipident addresses, can't be empty
   (mandatory if SMTP output is enabled)
@@ -696,8 +698,13 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **SMTP_MINIMUMPRIORITY** : minimum priority of event for using this output,
   order is
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
-- **OPSGENIE_APIKEY** : Opsgenie API Key, if not empty, Opsgenie output is
-  _enabled_
+- **SMTP_AUTHMECHANISM** : SASL Mechanisms `plain|oauthbearer|external|anonymous or "" (disable SASL)` Default to `plain`
+- **SMTP_USER** :  user for Plain Mechanism
+- **SMTP_PASSWORD** : password for Plain Mechanism
+- **SMTP_TOKEN** : # OAuthBearer token for OAuthBearer Mechanism
+- **SMTP_IDENTITY** : identity string for Plain and External Mechanisms
+- **SMTP_TRACE** : trace string for Anonymous Mechanism
+- **OPSGENIE_APIKEY** : Opsgenie API Key, if not empty, Opsgenie output is _enabled_
 - **OPSGENIE_REGION** : (us|eu) region of your domain (default is 'us')
 - **OPSGENIE_MINIMUMPRIORITY** : minimum priority of event for using this
   output, order is

--- a/config.go
+++ b/config.go
@@ -150,12 +150,17 @@ func getConfig() *types.Configuration {
 	v.SetDefault("AWS.Kinesis.MinimumPriority", "")
 
 	v.SetDefault("SMTP.HostPort", "")
-	v.SetDefault("SMTP.User", "")
-	v.SetDefault("SMTP.Password", "")
 	v.SetDefault("SMTP.From", "")
 	v.SetDefault("SMTP.To", "")
 	v.SetDefault("SMTP.OutputFormat", "html")
 	v.SetDefault("SMTP.MinimumPriority", "")
+
+	v.SetDefault("SMTP.AuthMechanism", "plain")
+	v.SetDefault("SMTP.User", "")
+	v.SetDefault("SMTP.Password", "")
+	v.SetDefault("SMTP.Token", "")
+	v.SetDefault("SMTP.Identity", "")
+	v.SetDefault("SMTP.Trace", "")
 
 	v.SetDefault("STAN.HostPort", "")
 	v.SetDefault("STAN.ClusterID", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -127,8 +127,12 @@ aws:
 
 smtp:
   # hostport: "" # host:port address of SMTP server, if not empty, SMTP output is enabled
-  # user: "" # user to access SMTP server
-  # password: "" # password to access SMTP server
+  # authmechanism: "plain" # SASL Mechanisms : plain, oauthbearer, external, anonymous or "" (disable SASL). Default: plain
+  # user: "" # user for Plain Mechanism
+  # password: "" # password for Plain Mechanism
+  # token: "" # OAuthBearer token for OAuthBearer Mechanism
+  # identity: "" # identity string for Plain and External Mechanisms
+  # trace: "" trace string for Anonymous Mechanism
   # from: "" # Sender address (mandatory if SMTP output is enabled)
   # to: "" # comma-separated list of Recipident addresses, can't be empty (mandatory if SMTP output is enabled)
   # outputformat: "" # html (default), text

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -53,6 +53,8 @@ var ErrTooManyRequest = errors.New("exceeding post rate limit")
 // ErrClientCreation is returned if client can't be created
 var ErrClientCreation = errors.New("client creation Error")
 
+var ErrSASLAuthCreation = errors.New("sasl auth: wrong mechanism")
+
 // EnabledOutputs list all enabled outputs
 var EnabledOutputs []string
 

--- a/outputs/constants.go
+++ b/outputs/constants.go
@@ -45,4 +45,10 @@ const (
 
 	UDP string = "udp"
 	TCP string = "tcp"
+
+	// SASL Auth mechanisms for SMTP
+	Plain       string = "plain"
+	OAuthBearer string = "oauthbearer"
+	External    string = "external"
+	Anonymous   string = "anonymous"
 )

--- a/types/types.go
+++ b/types/types.go
@@ -271,8 +271,12 @@ type awsKinesisConfig struct {
 
 type smtpOutputConfig struct {
 	HostPort        string
+	AuthMechanism   string
 	User            string
 	Password        string
+	Token           string
+	Identity        string
+	Trace           string
 	From            string
 	To              string
 	OutputFormat    string


### PR DESCRIPTION
Signed-off-by: Lyonel Martinez <lyonel.martinez@numberly.com>

**What type of PR is this?**

/kind documentation

/kind feature

**Any specific area of the project related to this PR?**

/area config

/area outputs

**What this PR does / why we need it**:

SMTP output may now use any SASL Auth mechanisms from: Plain, OAuth-Bearer, External, Anonymous or may not use any SASL Authentication. Default to Plain. 

~~Breaking change:~~
~~- The configuration for SMTP's User/Password is now in the yaml sub-object 'auth' of the SMTP configuration~~

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

~~Need some feedbacks on:~~
~~- I moved the User/password infos in the 'auth' sub-object, but if we want to avoid breaking changes, I can change the config to flatten it. WDYT ?~~


