### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,8 @@
 approvers:
   - Issif
-  - leodido
-  - nibalizer
   - leogr
   - cpanato
-  - KeisukeYamashita
   - fjogeleit
-  - developer-guy
 reviewers:
   - Issif
   - leodido
@@ -15,4 +11,9 @@ reviewers:
   - cpanato
   - KeisukeYamashita
   - fjogeleit
+  - developer-guy
+emeritus_approvers:
+  - leodido
+  - nibalizer
+  - KeisukeYamashita
   - developer-guy


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

For https://github.com/falcosecurity/falco/issues/2115, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from `approvers` to `emeritus_approvers` in OWNERS.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

