### PR TITLE
chore(OWNERS): remove duplicates in reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,15 +3,6 @@ approvers:
   - leogr
   - cpanato
   - fjogeleit
-reviewers:
-  - Issif
-  - leodido
-  - nibalizer
-  - leogr
-  - cpanato
-  - KeisukeYamashita
-  - fjogeleit
-  - developer-guy
 emeritus_approvers:
   - leodido
   - nibalizer


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce [jasondellaluce@gmail.com](mailto:jasondellaluce@gmail.com)

What type of PR is this?

/kind cleanup

/kind documentation

Any specific area of the project related to this PR?

/area build

What this PR does / why we need it:

For https://github.com/falcosecurity/falco/issues/2115, this removes duplicates in OWNERS for members that are both in the reviewers and in the approvers or emeritus_approvers section.

Which issue(s) this PR fixes:

Special notes for your reviewer: