### PR TITLE
fix missing Checkcert parameter + wrong logic with its usage

### DIFF
--- a/outputs/client.go
+++ b/outputs/client.go
@@ -129,7 +129,7 @@ func NewClient(outputType string, defaultEndpointURL string, mutualTLSEnabled bo
 		log.Printf("[ERROR] : %v - %v\n", outputType, err.Error())
 		return nil, ErrClientCreation
 	}
-	return &Client{OutputType: outputType, EndpointURL: endpointURL, MutualTLSEnabled: mutualTLSEnabled, HeaderList: []Header{}, ContentType: DefaultContentType, Config: config, Stats: stats, PromStats: promStats, StatsdClient: statsdClient, DogstatsdClient: dogstatsdClient}, nil
+	return &Client{OutputType: outputType, EndpointURL: endpointURL, MutualTLSEnabled: mutualTLSEnabled, CheckCert: checkCert, HeaderList: []Header{}, ContentType: DefaultContentType, Config: config, Stats: stats, PromStats: promStats, StatsdClient: statsdClient, DogstatsdClient: dogstatsdClient}, nil
 }
 
 // Post sends event (payload) to Output.
@@ -178,7 +178,7 @@ func (c *Client) Post(payload interface{}) error {
 		}
 	} else {
 		// With MutualTLS enabled, the check cert flag is ignored
-		if c.CheckCert {
+		if !c.CheckCert {
 			// #nosec G402 This is only set as a result of explicit configuration
 			customTransport.TLSClientConfig = &tls.Config{
 				InsecureSkipVerify: true,

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -34,7 +34,7 @@ func TestNewClient(t *testing.T) {
 	stats := &types.Statistics{}
 	promStats := &types.PromStatistics{}
 
-	testClientOutput := Client{OutputType: "test", EndpointURL: u, MutualTLSEnabled: false, HeaderList: []Header{}, ContentType: "application/json; charset=utf-8", Config: config, Stats: stats, PromStats: promStats}
+	testClientOutput := Client{OutputType: "test", EndpointURL: u, MutualTLSEnabled: false, CheckCert: true, HeaderList: []Header{}, ContentType: "application/json; charset=utf-8", Config: config, Stats: stats, PromStats: promStats}
 	_, err := NewClient("test", "localhost/%*$¨^!/:;", false, true, config, stats, promStats, nil, nil)
 	require.NotNil(t, err)
 


### PR DESCRIPTION
Signed-off-by: Issif <issif+github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The `checkcert` setting for the outputs wasn't considered and the logic of its usage were reversed.

```
2022/07/20 10:15:41 [ERROR] : Elasticsearch - Post "https://localhost:9200/falco-2022.07.20/event": x509: certificate signed by unknown authority
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


