### PR TITLE
set ownerreference for policy reports

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -879,7 +879,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -41,6 +41,9 @@ var (
 	clusterPolicyReport *wgpolicy.ClusterPolicyReport = &wgpolicy.ClusterPolicyReport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterPolicyReportBaseName,
+			Labels: map[string]string{
+				"app.kubernetes.io/created-by": "falcosidekick",
+			},
 		},
 		Summary: wgpolicy.PolicyReportSummary{
 			Fail: 0,
@@ -263,7 +266,7 @@ func updateClusterPolicyReport(c *Client, event *wgpolicy.PolicyReportResult) er
 	clusterpr := c.Crdclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports()
 
 	if len(clusterPolicyReport.Results) == c.Config.PolicyReport.MaxEvents {
-		if c.Config.PolicyReport.PruneByPriority == true {
+		if c.Config.PolicyReport.PruneByPriority {
 			pruningLogicForClusterPolicyReport()
 		} else {
 			if clusterPolicyReport.Results[0].Severity == highpriority {
@@ -343,7 +346,7 @@ func pruningLogicForClusterPolicyReport() {
 }
 
 func summaryDeletionCluster(rep *wgpolicy.ClusterPolicyReport, deleteFailevent bool) {
-	if deleteFailevent == true {
+	if deleteFailevent {
 		rep.Summary.Fail--
 	} else {
 		rep.Summary.Warn--
@@ -351,7 +354,7 @@ func summaryDeletionCluster(rep *wgpolicy.ClusterPolicyReport, deleteFailevent b
 }
 
 func summaryDeletion(rep *wgpolicy.PolicyReport, deleteFailevent bool) {
-	if deleteFailevent == true {
+	if deleteFailevent {
 		rep.Summary.Fail--
 	} else {
 		rep.Summary.Warn--

--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -186,7 +186,7 @@ func updatePolicyReports(c *Client, namespace string, event *wgpolicy.PolicyRepo
 			ObjectMeta: metav1.ObjectMeta{
 				Name: policyReportBaseName + uuid.NewString()[:8],
 				Labels: map[string]string{
-					"app.kubernetes.io/managed-by": "falcosidekick",
+					"app.kubernetes.io/created-by": "falcosidekick",
 				},
 			},
 			Summary: wgpolicy.PolicyReportSummary{

--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -185,6 +185,9 @@ func updatePolicyReports(c *Client, namespace string, event *wgpolicy.PolicyRepo
 		policyReports[namespace] = &wgpolicy.PolicyReport{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: policyReportBaseName + uuid.NewString()[:8],
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "falcosidekick",
+				},
 			},
 			Summary: wgpolicy.PolicyReportSummary{
 				Fail: 0,


### PR DESCRIPTION
Signed-off-by: Issif <issif+github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Set the `OwnerReference` to the `Namespace` for `PolicyReports`

**Which issue(s) this PR fixes**:

#331 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


