### PR TITLE
feat(alertmanager-extra-infos): Adding extra labels or annotations the alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ alertmanager:
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
   # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
+  # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2
+  # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
@@ -608,6 +610,10 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **ALERTMANAGER_ENDPOINT** : alertmanager endpoint on which falcosidekick posts alerts, choice is:
   `"/api/v1/alerts" or "/api/v2/alerts" , default is "/api/v1/alerts"`
 - **ALERTMANAGER_EXPIRESAFTER** : if set to a non-zero value, alert expires after that time in seconds (default: 0)
+- **ALERTMANAGER_EXTRALABELS** : comma separated list of labels composed of a ':' separated name and value that is 
+  added to the Alerts. Example: `my_label_1:my_value_1, my_label_1:my_value_2` (default: `""`)
+- **ALERTMANAGER_EXTRAANNOTATIONS** : comma separated list of annotations composed of a ':' separated name and
+  value that is added to the Alerts. Example: `my_annotation_1:my_value_1, my_annotation_1:my_value_2` (default: `""`)
 - **ELASTICSEARCH_HOSTPORT** : Elasticsearch http://host:port, if not `empty`,
   Elasticsearch is _enabled_
 - **ELASTICSEARCH_INDEX** : Elasticsearch index (default: falco)

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -55,6 +55,8 @@ alertmanager:
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
   # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
+  # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2
+  # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -83,6 +83,12 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 	if config.Alertmanager.ExpiresAfter != 0 {
 		amPayload.EndsAt = falcopayload.Time.Add(time.Duration(config.Alertmanager.ExpiresAfter) * time.Second)
 	}
+	for label, value := range config.Alertmanager.ExtraLabels {
+		amPayload.Labels[label] = value
+	}
+	for annotation, value := range config.Alertmanager.ExtraAnnotations {
+		amPayload.Annotations[annotation] = value
+	}
 
 	var a []alertmanagerPayload
 

--- a/types/types.go
+++ b/types/types.go
@@ -167,12 +167,14 @@ type DiscordOutputConfig struct {
 }
 
 type AlertmanagerOutputConfig struct {
-	HostPort        string
-	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
-	Endpoint        string
-	ExpiresAfter    int
+	HostPort         string
+	MinimumPriority  string
+	CheckCert        bool
+	MutualTLS        bool
+	Endpoint         string
+	ExpiresAfter     int
+	ExtraLabels      map[string]string
+	ExtraAnnotations map[string]string
 }
 
 type elasticsearchOutputConfig struct {


### PR DESCRIPTION
Signed-off-by: Lyonel Martinez <lyonel.martinez@numberly.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

Now, we can add extra labels and extra annotations to the alerts send to the AlertManager Output.
Each label/annotation can have a name and a value defined by this format:
```
config:
    alertmanager:
        extralabels: "label1:value1, label2:value2"
        extraannotations: "annotation1:value1, annotation2:value2"
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

We can use the same format to add extra labels with values to the Prometheus' extra-labels configuration and to the Loki one's.
