### PR TITLE
Update the default type for Elasticsearch docs from 'event' to '_doc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ alertmanager:
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
   # index: "falco" # index (default: falco)
-  # type: "event"
+  # type: "_doc"
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
@@ -617,7 +617,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **ELASTICSEARCH_HOSTPORT** : Elasticsearch http://host:port, if not `empty`,
   Elasticsearch is _enabled_
 - **ELASTICSEARCH_INDEX** : Elasticsearch index (default: falco)
-- **ELASTICSEARCH_TYPE** : Elasticsearch document type (default: event)
+- **ELASTICSEARCH_TYPE** : Elasticsearch document type (default: _doc)
 - **ELASTICSEARCH_MINIMUMPRIORITY** : minimum priority of event for using this
   output, order is
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`

--- a/config.go
+++ b/config.go
@@ -99,7 +99,7 @@ func getConfig() *types.Configuration {
 
 	v.SetDefault("Elasticsearch.HostPort", "")
 	v.SetDefault("Elasticsearch.Index", "falco")
-	v.SetDefault("Elasticsearch.Type", "event")
+	v.SetDefault("Elasticsearch.Type", "_doc")
 	v.SetDefault("Elasticsearch.MinimumPriority", "")
 	v.SetDefault("Elasticsearch.Suffix", "daily")
 	v.SetDefault("Elasticsearch.MutualTls", false)

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -61,7 +61,7 @@ alertmanager:
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
   # index: "falco" # index (default: falco)
-  # type: "event"
+  # type: "_doc"
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -219,17 +219,13 @@ func (c *Client) Post(payload interface{}) error {
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: //200, 201, 202, 204
 		log.Printf("[INFO]  : %v - Post OK (%v)\n", c.OutputType, resp.StatusCode)
 		body, _ := ioutil.ReadAll(resp.Body)
-		if c.OutputType == Kubeless {
-			log.Printf("[INFO]  : Kubeless - Function Response : %v\n", string(body))
-		} else if c.OutputType == Openfaas {
-			log.Printf("[INFO]  : %v - Function Response : %v\n", Openfaas,
-				string(body))
-		} else if c.OutputType == Fission {
-			log.Printf("[INFO]  : %v - Function Response : %v\n", Fission, string(body))
+		if ot := c.OutputType; ot == Kubeless || ot == Openfaas || ot == Fission {
+			log.Printf("[INFO]  : %v - Function Response : %v\n", ot, string(body))
 		}
 		return nil
 	case http.StatusBadRequest: //400
-		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrHeaderMissing, resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrHeaderMissing, resp.StatusCode, string(body))
 		return ErrHeaderMissing
 	case http.StatusUnauthorized: //401
 		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrClientAuthenticationError, resp.StatusCode)


### PR DESCRIPTION
… + print message body for http error 400

Signed-off-by: Issif <issif+github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

 /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

> /area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The Elasticsearch has been created years ago, the Elasticsearch engine changed since, and the `type` is now deprecated for a while, the value to use is `_doc`. This PR sets `_doc` as the default type for the ES docs.
The issues we got from community noticed http 400 errors without details, so the PR introduces a print of the body message for this error code to help debug (in case of ES, it prints the wrong mapping for eg).

**Which issue(s) this PR fixes**:

#348 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


