### PR TITLE
update Loki output to reflect the new API (version before of Loki <1 …

### DIFF
--- a/config.go
+++ b/config.go
@@ -120,7 +120,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Loki.MutualTLS", false)
 	v.SetDefault("Loki.CheckCert", true)
 	v.SetDefault("Loki.Tenant", "")
-	v.SetDefault("Loki.Endpoint", "/api/prom/push")
+	v.SetDefault("Loki.Endpoint", "/loki/api/v1/push")
 	v.SetDefault("Loki.ExtraLabels", "")
 
 	v.SetDefault("AWS.AccessKeyID", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -86,7 +86,7 @@ loki:
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # tenant: "" # Add the tenant header if needed. Tenant header is enabled only if not empty
-  # endpoint: "/api/prom/push" # The endpoint URL path, default is "/api/prom/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
+  # endpoint: "/loki/api/v1/push" # The endpoint URL path, default is "/loki/api/v1/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
   # extralabels: "" # comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields
 
 nats:

--- a/outputs/loki_test.go
+++ b/outputs/loki_test.go
@@ -13,13 +13,13 @@ func TestNewLokiPayload(t *testing.T) {
 	expectedOutput := lokiPayload{
 		Streams: []lokiStream{
 			{
-				Labels: "{tags=\"test,example\",rule=\"Test rule\",source=\"syscalls\",priority=\"Debug\"}",
-				Entries: []lokiEntry{
-					{
-						Ts:   "2001-01-01T01:10:00Z",
-						Line: "This is a test from falcosidekick",
-					},
+				Stream: map[string]string{
+					"tags":     "test,example",
+					"rule":     "Test rule",
+					"source":   "syscalls",
+					"priority": "Debug",
 				},
+				Values: []lokiValue{[]string{"978311400000000000", "This is a test from falcosidekick"}},
 			},
 		},
 	}


### PR DESCRIPTION
…are now deprecated)

Signed-off-by: Thomas Labarussias <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR updates the default endpoint for Loki output and update the payload format to match the current format

:warning: Loki < v1 are now deprecated

**Which issue(s) this PR fixes**:

#351 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


