### PR TITLE
fix issue with SNS when output fields keys have brackets + add SNS pr…

### DIFF
--- a/outputs/aws.go
+++ b/outputs/aws.go
@@ -238,7 +238,7 @@ func (c *Client) PublishTopic(falcopayload types.FalcoPayload) {
 			case string:
 				msg.MessageAttributes[i] = &sns.MessageAttributeValue{
 					DataType:    aws.String("String"),
-					StringValue: aws.String(v),
+					StringValue: aws.String(strings.ReplaceAll(strings.ReplaceAll(v, "]", ""), "[", ".")),
 				}
 			default:
 				continue
@@ -257,7 +257,7 @@ func (c *Client) PublishTopic(falcopayload types.FalcoPayload) {
 		go c.CountMetric("outputs", 1, []string{"output:awssns", "status:error"})
 		c.Stats.AWSSNS.Add(Error, 1)
 		c.PromStats.Outputs.With(map[string]string{"destination": "awssns", "status": Error}).Inc()
-		log.Printf("[ERROR] : %v - %v\n", c.OutputType, err.Error())
+		log.Printf("[ERROR] : %v SNS - %v\n", c.OutputType, err.Error())
 		return
 	}
 


### PR DESCRIPTION
…efix for the error log

Signed-off-by: Thomas Labarussias <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

When an output field key contains `[  ]`, AWS SNS rejects the event:

```
    "output_fields": {
        "proc.aname[2]": "a",
        "proc.aname[3]": "b",
        "proc.aname[4]": "c",
``` 
```
2022/10/21 10:24:29 [ERROR] : AWS - ParameterValueInvalid: Invalid non-alphanumeric character '#x5B' was found in the message attribute name. Can only include alphanumeric characters, hyphens, underscores, or dots.
        status code: 400, request id: e25afdea-92c9-5601-8774-a626e754408b
```

I've also fixed the missing SNS header for the log line.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
