### PR TITLE
allow to set user and api key for Loki output when Grafana Logs is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ influxdb:
 
 loki:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Loki output is enabled
+  # user: "" # user for Grafana Logs
+  # apikey: "" # API Key for Grafana Logs
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # tenant: "" # Add the tenant header if needed. Enabled if not empty
@@ -696,6 +698,8 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **INFLUXDB_CHECKCERT** : check if ssl certificate of the output is valid (default:
   `true`)
 - **LOKI_HOSTPORT** : Loki http://host:port, if not `empty`, Loki is _enabled_
+- **LOKI_USER** : User for Grafana Logs
+- **LOKI_APIKEY** : API Key for Grafana Logs
 - **LOKI_MINIMUMPRIORITY** : minimum priority of event for using this output,
   order is
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`

--- a/config.go
+++ b/config.go
@@ -121,6 +121,8 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Influxdb.CheckCert", true)
 
 	v.SetDefault("Loki.HostPort", "")
+	v.SetDefault("Loki.User", "")
+	v.SetDefault("Loki.APIKey", "")
 	v.SetDefault("Loki.MinimumPriority", "")
 	v.SetDefault("Loki.MutualTLS", false)
 	v.SetDefault("Loki.CheckCert", true)

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -87,10 +87,12 @@ influxdb:
 
 loki:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Loki output is enabled
+  # user: "" # user for Grafana Logs
+  # apikey: "" # API Key for Grafana Logs
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
-  # tenant: "" # Add the tenant header if needed. Tenant header is enabled only if not empty
+  # tenant: "" # Add the Tenant header
   # endpoint: "/loki/api/v1/push" # The endpoint URL path, default is "/loki/api/v1/push" more info : https://grafana.com/docs/loki/latest/api/#post-apiprompush
   # extralabels: "" # comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields
 

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -247,19 +247,24 @@ func (c *Client) Post(payload interface{}) error {
 		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrHeaderMissing, resp.StatusCode, string(body))
 		return ErrHeaderMissing
 	case http.StatusUnauthorized: //401
-		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrClientAuthenticationError, resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrClientAuthenticationError, resp.StatusCode, string(body))
 		return ErrClientAuthenticationError
 	case http.StatusForbidden: //403
-		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrForbidden, resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrForbidden, resp.StatusCode, string(body))
 		return ErrForbidden
 	case http.StatusNotFound: //404
-		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrNotFound, resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrNotFound, resp.StatusCode, string(body))
 		return ErrNotFound
 	case http.StatusUnprocessableEntity: //422
-		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrUnprocessableEntityError, resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrUnprocessableEntityError, resp.StatusCode, string(body))
 		return ErrUnprocessableEntityError
 	case http.StatusTooManyRequests: //429
-		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrTooManyRequest, resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] : %v - %v (%v): %v\n", c.OutputType, ErrTooManyRequest, resp.StatusCode, string(body))
 		return ErrTooManyRequest
 	case http.StatusInternalServerError: //500
 		log.Printf("[ERROR] : %v - %v (%v)\n", c.OutputType, ErrTooManyRequest, resp.StatusCode)

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -66,6 +66,10 @@ func (c *Client) LokiPost(falcopayload types.FalcoPayload) {
 		c.AddHeader("X-Scope-OrgID", c.Config.Loki.Tenant)
 	}
 
+	if c.Config.Loki.User != "" && c.Config.Loki.APIKey != "" {
+		c.BasicAuth(c.Config.Loki.User, c.Config.Loki.APIKey)
+	}
+
 	err := c.Post(newLokiPayload(falcopayload, c.Config))
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:loki", "status:error"})

--- a/types/types.go
+++ b/types/types.go
@@ -228,6 +228,8 @@ type influxdbOutputConfig struct {
 
 type lokiOutputConfig struct {
 	HostPort        string
+	User            string
+	APIKey          string
 	MinimumPriority string
 	CheckCert       bool
 	MutualTLS       bool


### PR DESCRIPTION
…ed + print the body for all 40x errors

Signed-off-by: Thomas Labarussias <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

 /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR allows to set up User + API Key for Loki output, this allows to use the SaaS version of Loki, Grafana Logs.

To make easier the debugging, the response body is now printed for all 40x errors

**Which issue(s) this PR fixes**:

#377 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


