### PR TITLE
Update Pull Request: "feat: Add hostname to payload"

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -73,6 +73,9 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 	amPayload.Labels["source"] = "falco"
 	amPayload.Labels["rule"] = falcopayload.Rule
 	amPayload.Labels["eventsource"] = falcopayload.Source
+	if falcopayload.Hostname != "" {
+		amPayload.Labels[Hostname] = falcopayload.Hostname
+	}
 	if len(falcopayload.Tags) != 0 {
 		amPayload.Labels["tags"] = strings.Join(falcopayload.Tags, ",")
 	}

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestNewAlertmanagerPayloadO(t *testing.T) {
-	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","eventsource":"syscalls","rule":"Test rule","source":"falco","tags":"test,example"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
-
+	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","eventsource":"syscalls","hostname":"test-host","rule":"Test rule","source":"falco","tags":"test,example"},"annotations":{"info":"This is a test from falcosidekick","summary":"Test rule"}}]`
 	var f types.FalcoPayload
 	d := json.NewDecoder(strings.NewReader(falcoTestInput))
 	d.UseNumber()

--- a/outputs/aws.go
+++ b/outputs/aws.go
@@ -232,7 +232,12 @@ func (c *Client) PublishTopic(falcopayload types.FalcoPayload) {
 				StringValue: aws.String(strings.Join(falcopayload.Tags, ",")),
 			}
 		}
-
+		if falcopayload.Hostname != "" {
+			msg.MessageAttributes[Hostname] = &sns.MessageAttributeValue{
+				DataType:    aws.String("String"),
+				StringValue: aws.String(falcopayload.Hostname),
+			}
+		}
 		for i, j := range falcopayload.OutputFields {
 			switch v := j.(type) {
 			case string:

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
-var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule", "time":"2001-01-01T01:10:00Z","source":"syscalls","output_fields": {"proc.name":"falcosidekick", "proc.tty": 1234}, "tags":["test","example"]}`
+var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule", "time":"2001-01-01T01:10:00Z","source":"syscalls","output_fields": {"proc.name":"falcosidekick", "proc.tty": 1234}, "tags":["test","example"], "hostname":"test-host"}`
 
 func TestNewClient(t *testing.T) {
 	u, _ := url.Parse("http://localhost")

--- a/outputs/cliq.go
+++ b/outputs/cliq.go
@@ -100,6 +100,12 @@ func newCliqPayload(falcopayload types.FalcoPayload, config *types.Configuration
 		field.Value = falcopayload.Priority.String()
 		table.Rows = append(table.Rows, field)
 
+		if falcopayload.Hostname != "" {
+			field.Field = Hostname
+			field.Value = falcopayload.Hostname
+			table.Rows = append(table.Rows, field)
+		}
+
 		for _, i := range getSortedStringKeys(falcopayload.OutputFields) {
 			field.Field = i
 			field.Value = falcopayload.OutputFields[i].(string)

--- a/outputs/cliq_test.go
+++ b/outputs/cliq_test.go
@@ -40,6 +40,10 @@ func TestNewCliqPayload(t *testing.T) {
 							Value: "Debug",
 						},
 						{
+							Field: "hostname",
+							Value: "test-host",
+						},
+						{
 							Field: "proc.name",
 							Value: "falcosidekick",
 						},

--- a/outputs/cloudevents.go
+++ b/outputs/cloudevents.go
@@ -33,6 +33,10 @@ func (c *Client) CloudEventsSend(falcopayload types.FalcoPayload) {
 	event.SetExtension("rule", falcopayload.Rule)
 	event.SetExtension("source", falcopayload.Source)
 
+	if falcopayload.Hostname != "" {
+		event.SetExtension(Hostname, falcopayload.Hostname)
+	}
+
 	// Set Extensions.
 	for k, v := range c.Config.CloudEvents.Extensions {
 		event.SetExtension(k, v)

--- a/outputs/constants.go
+++ b/outputs/constants.go
@@ -29,6 +29,7 @@ const (
 	Plaintext string = "plaintext"
 	JSON      string = "json"
 	Markdown  string = "markdown"
+	Hostname  string = "hostname"
 
 	DefaultFooter  string = "https://github.com/falcosecurity/falcosidekick"
 	DefaultIconURL string = "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick.png"

--- a/outputs/datadog.go
+++ b/outputs/datadog.go
@@ -32,6 +32,9 @@ func newDatadogPayload(falcopayload types.FalcoPayload) datadogPayload {
 		}
 	}
 	tags = append(tags, "source:"+falcopayload.Source)
+	if falcopayload.Hostname != "" {
+		tags = append(tags, Hostname+":"+falcopayload.Hostname)
+	}
 	if len(falcopayload.Tags) != 0 {
 		tags = append(tags, falcopayload.Tags...)
 	}

--- a/outputs/datadog_test.go
+++ b/outputs/datadog_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestNewDatadogPayload(t *testing.T) {
-	expectedOutput := `{"title":"Test rule","text":"This is a test from falcosidekick","alert_type":"info","source_type_name":"falco","tags":["proc.name:falcosidekick", "source:syscalls", "test", "example"]}`
-
+	expectedOutput := `{"title":"Test rule","text":"This is a test from falcosidekick","alert_type":"info","source_type_name":"falco","tags":["proc.name:falcosidekick", "source:syscalls", "hostname:test-host", "test", "example"]}`
 	var f types.FalcoPayload
 	json.Unmarshal([]byte(falcoTestInput), &f)
 	s, _ := json.Marshal(newDatadogPayload(f))

--- a/outputs/discord.go
+++ b/outputs/discord.go
@@ -74,6 +74,9 @@ func newDiscordPayload(falcopayload types.FalcoPayload, config *types.Configurat
 	embedFields = append(embedFields, discordEmbedFieldPayload{Rule, falcopayload.Rule, true})
 	embedFields = append(embedFields, discordEmbedFieldPayload{Priority, falcopayload.Priority.String(), true})
 	embedFields = append(embedFields, discordEmbedFieldPayload{Source, falcopayload.Source, true})
+	if falcopayload.Hostname != "" {
+		embedFields = append(embedFields, discordEmbedFieldPayload{Hostname, falcopayload.Hostname, true})
+	}
 	if len(falcopayload.Tags) != 0 {
 		embedFields = append(embedFields, discordEmbedFieldPayload{Tags, strings.Join(falcopayload.Tags, ", "), true})
 	}

--- a/outputs/discord_test.go
+++ b/outputs/discord_test.go
@@ -41,6 +41,11 @@ func TestNewDiscordPayload(t *testing.T) {
 						Inline: true,
 					},
 					{
+						Name:   "hostname",
+						Value:  "test-host",
+						Inline: true,
+					},
+					{
 						Name:   "tags",
 						Value:  "test, example",
 						Inline: true,

--- a/outputs/googlechat.go
+++ b/outputs/googlechat.go
@@ -68,6 +68,10 @@ func newGooglechatPayload(falcopayload types.FalcoPayload, config *types.Configu
 	widgets = append(widgets, widget{KeyValue: keyValue{"priority", falcopayload.Priority.String()}})
 	widgets = append(widgets, widget{KeyValue: keyValue{"source", falcopayload.Source}})
 
+	if falcopayload.Hostname != "" {
+		widgets = append(widgets, widget{KeyValue: keyValue{Hostname, falcopayload.Hostname}})
+	}
+
 	if len(falcopayload.Tags) != 0 {
 		widgets = append(widgets, widget{
 			KeyValue: keyValue{

--- a/outputs/googlechat_test.go
+++ b/outputs/googlechat_test.go
@@ -44,6 +44,12 @@ func TestNewGoogleChatPayload(t *testing.T) {
 							},
 							{
 								keyValue{
+									TopLabel: "hostname",
+									Content:  "test-host",
+								},
+							},
+							{
+								keyValue{
 									TopLabel: "tags",
 									Content:  "test, example",
 								},

--- a/outputs/grafana.go
+++ b/outputs/grafana.go
@@ -26,6 +26,10 @@ func newGrafanaPayload(falcopayload types.FalcoPayload, config *types.Configurat
 		falcopayload.Rule,
 		falcopayload.Source,
 	}
+	if falcopayload.Hostname != "" {
+		tags = append(tags, falcopayload.Hostname)
+	}
+
 	if config.Grafana.AllFieldsAsTags {
 		for _, i := range falcopayload.OutputFields {
 			tags = append(tags, fmt.Sprintf("%v", i))

--- a/outputs/influxdb.go
+++ b/outputs/influxdb.go
@@ -21,6 +21,10 @@ func newInfluxdbPayload(falcopayload types.FalcoPayload, config *types.Configura
 		}
 	}
 
+	if falcopayload.Hostname != "" {
+		s += "," + Hostname + "=" + falcopayload.Hostname
+	}
+
 	if len(falcopayload.Tags) != 0 {
 		s += ",tags=" + strings.Join(falcopayload.Tags, "_")
 	}

--- a/outputs/influxdb_test.go
+++ b/outputs/influxdb_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestNewInfluxdbPayload(t *testing.T) {
-	expectedOutput := `"events,rule=Test_rule,priority=Debug,source=syscalls,proc.name=falcosidekick,tags=test_example value=\"This is a test from falcosidekick\""`
-
+	expectedOutput := `"events,rule=Test_rule,priority=Debug,source=syscalls,proc.name=falcosidekick,hostname=test-host,tags=test_example value=\"This is a test from falcosidekick\""`
 	var f types.FalcoPayload
 	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
 

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -46,6 +46,10 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 		}
 	}
 
+	if falcopayload.Hostname != "" {
+		s[Hostname] = falcopayload.Hostname
+	}
+
 	if len(falcopayload.Tags) != 0 {
 		s["tags"] = strings.Join(falcopayload.Tags, ",")
 	}

--- a/outputs/loki_test.go
+++ b/outputs/loki_test.go
@@ -14,6 +14,7 @@ func TestNewLokiPayload(t *testing.T) {
 		Streams: []lokiStream{
 			{
 				Stream: map[string]string{
+					"hostname": "test-host",
 					"tags":     "test,example",
 					"rule":     "Test rule",
 					"source":   "syscalls",

--- a/outputs/mattermost.go
+++ b/outputs/mattermost.go
@@ -22,6 +22,12 @@ func newMattermostPayload(falcopayload types.FalcoPayload, config *types.Configu
 		field.Value = falcopayload.Rule
 		field.Short = true
 		fields = append(fields, field)
+		if falcopayload.Hostname != "" {
+			field.Title = Hostname
+			field.Value = falcopayload.Hostname
+			field.Short = true
+			fields = append(fields, field)
+		}
 		field.Title = Priority
 		field.Value = falcopayload.Priority.String()
 		field.Short = true

--- a/outputs/mattermost_test.go
+++ b/outputs/mattermost_test.go
@@ -28,6 +28,11 @@ func TestMattermostPayload(t *testing.T) {
 						Short: true,
 					},
 					{
+						Title: "hostname",
+						Value: "test-host",
+						Short: true,
+					},
+					{
 						Title: "priority",
 						Value: "Debug",
 						Short: true,

--- a/outputs/opsgenie.go
+++ b/outputs/opsgenie.go
@@ -29,6 +29,9 @@ func newOpsgeniePayload(falcopayload types.FalcoPayload, config *types.Configura
 	details["source"] = falcopayload.Source
 	details["rule"] = falcopayload.Rule
 	details["priority"] = falcopayload.Priority.String()
+	if falcopayload.Hostname != "" {
+		details[Hostname] = falcopayload.Hostname
+	}
 	if len(falcopayload.Tags) != 0 {
 		details["tags"] = strings.Join(falcopayload.Tags, ", ")
 	}

--- a/outputs/opsgenie_test.go
+++ b/outputs/opsgenie_test.go
@@ -15,6 +15,7 @@ func TestNewOpsgeniePayload(t *testing.T) {
 		Entity:      "Falcosidekick",
 		Description: "Test rule",
 		Details: map[string]string{
+			"hostname":  "test-host",
 			"priority":  "Debug",
 			"tags":      "test, example",
 			"proc_name": "falcosidekick",

--- a/outputs/pagerduty.go
+++ b/outputs/pagerduty.go
@@ -35,6 +35,9 @@ func createPagerdutyEvent(falcopayload types.FalcoPayload, config types.Pagerdut
 	details["rule"] = falcopayload.Rule
 	details["priority"] = falcopayload.Priority.String()
 	details["source"] = falcopayload.Source
+	if len(falcopayload.Hostname) != 0 {
+		falcopayload.OutputFields[Hostname] = falcopayload.Hostname
+	}
 	if len(falcopayload.Tags) != 0 {
 		details["tags"] = strings.Join(falcopayload.Tags, ", ")
 	}

--- a/outputs/pagerduty_test.go
+++ b/outputs/pagerduty_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestPagerdutyPayload(t *testing.T) {
-	var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule","time":"2001-01-01T01:10:00Z","output_fields": {"proc.name":"falcosidekick", "proc.tty": 1234}}`
-
+	var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule","hostname":"test-host","time":"2001-01-01T01:10:00Z","output_fields": {"hostname": "test-host", "proc.name":"falcosidekick", "proc.tty": 1234}}`
 	var excpectedOutput = pagerduty.V2Event{
 		RoutingKey: "",
 		Action:     "trigger",
@@ -25,6 +24,7 @@ func TestPagerdutyPayload(t *testing.T) {
 			Group:     "",
 			Class:     "",
 			Details: map[string]interface{}{
+				"hostname":  "test-host",
 				"proc.name": "falcosidekick",
 				"proc.tty":  float64(1234),
 			},

--- a/outputs/rocketchat.go
+++ b/outputs/rocketchat.go
@@ -52,6 +52,12 @@ func newRocketchatPayload(falcopayload types.FalcoPayload, config *types.Configu
 		field.Short = false
 		field.Value = falcopayload.Time.String()
 		fields = append(fields, field)
+		if falcopayload.Hostname != "" {
+			field.Title = Hostname
+			field.Value = falcopayload.Hostname
+			field.Short = true
+			fields = append(fields, field)
+		}
 	}
 
 	attachment.Fallback = falcopayload.Output

--- a/outputs/rocketchat_test.go
+++ b/outputs/rocketchat_test.go
@@ -52,6 +52,11 @@ func TestNewRocketchatPayload(t *testing.T) {
 						Value: "2001-01-01 01:10:00 +0000 UTC",
 						Short: false,
 					},
+					{
+						Title: "hostname",
+						Value: "test-host",
+						Short: true,
+					},
 				},
 			},
 		},

--- a/outputs/slack.go
+++ b/outputs/slack.go
@@ -55,6 +55,12 @@ func newSlackPayload(falcopayload types.FalcoPayload, config *types.Configuratio
 		field.Value = falcopayload.Source
 		field.Short = true
 		fields = append(fields, field)
+		if falcopayload.Hostname != "" {
+			field.Title = Hostname
+			field.Value = falcopayload.Hostname
+			field.Short = true
+			fields = append(fields, field)
+		}
 		if len(falcopayload.Tags) != 0 {
 			field.Title = Tags
 			field.Value = strings.Join(falcopayload.Tags, ", ")

--- a/outputs/slack_test.go
+++ b/outputs/slack_test.go
@@ -38,6 +38,11 @@ func TestNewSlackPayload(t *testing.T) {
 						Short: true,
 					},
 					{
+						Title: "hostname",
+						Value: "test-host",
+						Short: true,
+					},
+					{
 						Title: "tags",
 						Value: "test, example",
 						Short: true,

--- a/outputs/smtp_templates.go
+++ b/outputs/smtp_templates.go
@@ -4,6 +4,7 @@ var plaintextTmpl = `Priority: {{ .Priority }}
 Output: {{ .Output }}
 Rule: {{ .Rule }}
 Source: {{ .Source }}
+Hostname: {{ .Hostname }}
 Tags: {{ range .Tags }}{{ . }} {{ end }}
 Time: {{ .Time }}
 
@@ -59,6 +60,10 @@ var htmlTmpl = `
         <tr>
             <td style="background-color:#858585"><span style="font-size:14px;color:#fff;"><strong>Source</strong></span></td>
             <td style="background-color:#d1d6da">{{ .Source }}</td>
+        </tr>
+		<tr>
+            <td style="background-color:#858585"><span style="font-size:14px;color:#fff;"><strong>Hostname</strong></span></td>
+            <td style="background-color:#d1d6da">{{ .Hostname }}</td>
         </tr>
         <tr>
             <td style="background-color:#858585"><span style="font-size:14px;color:#fff;"><strong>Tags</strong></span></td>

--- a/outputs/teams.go
+++ b/outputs/teams.go
@@ -69,6 +69,11 @@ func newTeamsPayload(falcopayload types.FalcoPayload, config *types.Configuratio
 		fact.Name = Source
 		fact.Value = falcopayload.Source
 		facts = append(facts, fact)
+		if falcopayload.Hostname != "" {
+			fact.Name = Hostname
+			fact.Value = falcopayload.Hostname
+			facts = append(facts, fact)
+		}
 		if len(falcopayload.Tags) != 0 {
 			fact.Name = Tags
 			fact.Value = strings.Join(falcopayload.Tags, ", ")

--- a/outputs/teams_test.go
+++ b/outputs/teams_test.go
@@ -38,6 +38,10 @@ func TestNewTeamsPayload(t *testing.T) {
 						Value: "syscalls",
 					},
 					{
+						Name:  "hostname",
+						Value: "test-host",
+					},
+					{
 						Name:  "tags",
 						Value: "test, example",
 					},

--- a/outputs/wavefront.go
+++ b/outputs/wavefront.go
@@ -71,6 +71,10 @@ func (c *Client) WavefrontPost(falcopayload types.FalcoPayload) {
 	tags["rule"] = falcopayload.Rule
 	tags["source"] = falcopayload.Source
 
+	if falcopayload.Hostname != "" {
+		tags[Hostname] = falcopayload.Hostname
+	}
+
 	for tag, value := range falcopayload.OutputFields {
 		switch v := value.(type) {
 		case string:

--- a/types/types.go
+++ b/types/types.go
@@ -19,6 +19,7 @@ type FalcoPayload struct {
 	OutputFields map[string]interface{} `json:"output_fields"`
 	Source       string                 `json:"source"`
 	Tags         []string               `json:"tags,omitempty"`
+	Hostname     string                 `json:"hostname,omitempty"`
 }
 
 func (f FalcoPayload) String() string {


### PR DESCRIPTION
What type of PR is this?

/kind feature

Any specific area of the project related to this PR?

/area config

/area outputs

What this PR does / why we need it:
As it's taking quite a long time,: applying the rebase asked by @Issif on https://github.com/falcosecurity/falcosidekick/pull/355 

Adds optional `hostname`  field to the incoming falco payload. Conditionally adds the hostname to all outputs.

Special notes for your reviewer:

For the outputs  `Spyderbat` and `TimescaleDB`, I don't really know if I need to apply some changes, as it would imply a schema modification for both while `Output` is already given.
