### PR TITLE
add CEF format for syslog output

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,8 @@ yandex:
 syslog:
   # host: "" # Syslog host, if not empty, Syslog output is enabled
   # port: "" # Syslog endpoint port number
-  # protocol: "" # Syslog transport protocol. It can be either "tcp" or "udp"
+  # protocol: "" # Syslog transport protocol. It can be either "tcp" or "udp" (default: tcp)
+  # format: "" # Syslog payload format. It can be either "json" or "cef" (default: json)
   # minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 mqtt:
@@ -965,7 +966,8 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **YANDEX_DATASTREAMS_MINIMUMPRIORITY**: # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
 - **SYSLOG_HOST**: Syslog Host, if not empty, Syslog output is enabled
 - **SYSLOG_PORT**: Syslog endpoint port number
-- **SYSLOG_PROTOCOL**: Syslog transport protocol. It can be either "tcp" or "udp"
+- **SYSLOG_PROTOCOL**: Syslog transport protocol. It can be either "tcp" or "udp" (default: tcp)
+- **SYSLOG_FORMAT**: Syslog payload format. It can be either "json" or "cef" (default: json)
 - **SYSLOG_MINIMUMPRIORITY**: minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default: "debug")
 - **POLICYREPORT_ENABLED**: if true policyreport output is enabled (default: `false`)
 - **POLICYREPORT_KUBECONFIG**: Kubeconfig file to use (only if falcosidekick is running outside the cluster)

--- a/config.go
+++ b/config.go
@@ -341,6 +341,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Syslog.Host", "")
 	v.SetDefault("Syslog.Port", "")
 	v.SetDefault("Syslog.Protocol", "")
+	v.SetDefault("Syslog.Format", "json")
 	v.SetDefault("Syslog.MinimumPriority", "")
 
 	v.SetDefault("MQTT.Broker", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -329,6 +329,13 @@ yandex:
     # streamname: "" # stream name in format /${region}/${folder_id}/${ydb_id}/${stream_name}
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug
 
+syslog:
+  # host: "" # Syslog host, if not empty, Syslog output is enabled
+  # port: "" # Syslog endpoint port number
+  # protocol: "" # Syslog transport protocol. It can be either "tcp" or "udp" (default: tcp)
+  # format: "" # Syslog payload format. It can be either "json" or "cef" (default: json)
+  # minimumpriority: "debug" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
+
 mqtt:
   broker: "" # Broker address, can start with tcp:// or ssl://, if not empty, MQTT output is enabled
   # topic: "falco/events" # Topic for messages (default: falco/events)

--- a/outputs/syslog.go
+++ b/outputs/syslog.go
@@ -3,11 +3,13 @@ package outputs
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-go/statsd"
-	"github.com/falcosecurity/falcosidekick/types"
 	"log"
 	"log/syslog"
 	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/falcosecurity/falcosidekick/types"
 )
 
 func NewSyslogClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
@@ -28,6 +30,29 @@ func NewSyslogClient(config *types.Configuration, stats *types.Statistics, promS
 
 func isValidProtocolString(protocol string) bool {
 	return protocol == TCP || protocol == UDP
+}
+
+func getCEFSeverity(priority types.PriorityType) string {
+	switch priority {
+	case types.Debug:
+		return "0"
+	case types.Informational:
+		return "3"
+	case types.Notice:
+		return "4"
+	case types.Warning:
+		return "6"
+	case types.Error:
+		return "7"
+	case types.Critical:
+		return "8"
+	case types.Alert:
+		return "9"
+	case types.Emergency:
+		return "10"
+	default:
+		return "Uknown"
+	}
 }
 
 func (c *Client) SyslogPost(falcopayload types.FalcoPayload) {
@@ -63,8 +88,34 @@ func (c *Client) SyslogPost(falcopayload types.FalcoPayload) {
 		return
 	}
 
-	b, _ := json.Marshal(falcopayload)
-	_, err = sysLog.Write(b)
+	var payload []byte
+
+	if c.Config.Syslog.Format == "cef" {
+		s := fmt.Sprintf(
+			"CEF:0|Falcosecurity|Falco|1.0|Falco Event|%v|%v|uuid=%v start=%v msg=%v source=%v",
+			falcopayload.Rule,
+			getCEFSeverity(falcopayload.Priority),
+			falcopayload.UUID,
+			falcopayload.Time.Format(time.RFC3339),
+			falcopayload.Output,
+			falcopayload.Source,
+		)
+		if falcopayload.Hostname != "" {
+			s += " hostname=" + falcopayload.Hostname
+		}
+		s += " outputfields="
+		for i, j := range falcopayload.OutputFields {
+			s += fmt.Sprintf("%v:%v ", i, j)
+		}
+		if len(falcopayload.Tags) != 0 {
+			s += "tags=" + strings.Join(falcopayload.Tags, ",")
+		}
+		payload = []byte(strings.TrimSuffix(s, " "))
+	} else {
+		payload, _ = json.Marshal(falcopayload)
+	}
+
+	_, err = sysLog.Write(payload)
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:syslog", "status:error"})
 		c.Stats.Syslog.Add(Error, 1)

--- a/types/types.go
+++ b/types/types.go
@@ -529,6 +529,7 @@ type SyslogConfig struct {
 	Host            string
 	Port            string
 	Protocol        string
+	Format          string
 	MinimumPriority string
 }
 


### PR DESCRIPTION
Signed-off-by: Thomas Labarussias <issif_github@gadz.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Support [CEF](https://learn.microsoft.com/en-us/azure/sentinel/cef-name-mapping) format for Syslog output

```
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Unexpected outbound connection destination|4|uuid=f1fe1e58-6f3f-4562-bc80-aafec699b45a start=2022-11-29T15:35:01Z msg=Disallowed outbound connection destination (command=%proc.cmdline pid=%proc.pid connection=%fd.name user=%user.name user_loginuid=%user.loginuid container_id=%container.id image=%container.image.repository) source=syscalls outputfields=fd.name:fd.name proc.pid:proc.pid user.loginuid:user.loginuid user.name:user.name ckey:CValue bkey:BValue dkey:bar container.id:container.id proc.cmdline:proc.cmdline akey:AValue container.image.repository:container.image.repository tags=network
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Console Login Through Assume Role|6|uuid=a23ab7aa-8e20-400d-a277-ac31bcb7d5ff start=2022-11-29T15:35:08Z msg=Detected a console login through Assume Role (principal=%ct.user.principalid, assumedRole=%ct.user.arn, requesting IP=%ct.srcip, AWS region=%ct.region) source=cloudtrail outputfields=akey:AValue dkey:bar ct.region:ct.region ct.srcip:ct.srcip ct.user.arn:ct.user.arn ct.user.principalid:ct.user.principalid bkey:BValue ckey:CValue tags=cloud,aws,aws_console,aws_iam
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Delete Public Repository|6|uuid=79889861-a713-4cc2-be18-ab58d7e7021a start=2022-11-29T15:35:27Z msg=A public repository was deleted (repository=%github.repo repo_owner=%github.owner org=%github.org user=%github.user) source=github outputfields=github.org:github.org github.owner:github.owner github.repo:github.repo github.user:github.user akey:AValue bkey:BValue ckey:CValue dkey:bar
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Modify Container Entrypoint|6|uuid=ec1b5986-b10a-4d35-9926-cc13c232a44e start=2022-11-29T15:35:45Z msg=Detect Potential Container Breakout Exploit (CVE-2019-5736) (user=%user.name process=%proc.name file=%fd.name cmdline=%proc.cmdline pid=%proc.pid %container.info)
 source=syscalls outputfields=proc.name:proc.name proc.pid:proc.pid user.name:user.name ckey:CValue bkey:BValue fd.name:fd.name proc.cmdline:proc.cmdline akey:AValue dkey:bar container.info:container.info tags=container,filesystem,mitre_initial_access
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Java Process Class File Download|8|uuid=5026648e-b962-4caa-82b0-3fcd1774637e start=2022-11-29T15:35:45Z msg=Java process class file download (user=%user.name user_loginname=%user.loginname user_loginuid=%user.loginuid event=%evt.type connection=%fd.name server_ip=%fd.sip server_port=%fd.sport proto=%fd.l4proto process=%proc.name command=%proc.cmdline pid=%proc.pid parent=%proc.pname buffer=%evt.buffer container_id=%container.id image=%container.image.repository) source=syscalls outputfields=container.id:container.id user.loginuid:user.loginuid user.name:user.name fd.l:fd.l fd.name:fd.name fd.sport:fd.sport proc.pname:proc.pname ckey:CValue bkey:BValue container.image.repository:container.image.repository evt.buffer:evt.buffer evt.type:evt.type fd.sip:fd.sip proc.cmdline:proc.cmdline proc.name:proc.name proc.pid:proc.pid user.loginname:user.loginname akey:AValue dkey:bar tags=mitre_initial_access
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Polkit Local Privilege Escalation Vulnerability (CVE-2021-4034)|8|uuid=c617fd89-f806-4d09-949d-eb8cc3c4225c start=2022-11-29T15:35:45Z msg=Detect Polkit pkexec Local Privilege Escalation Exploit (CVE-2021-4034) (user=%user.loginname uid=%user.loginuid command=%proc.cmdline pid=%proc.pid args=%proc.args) source=syscalls outputfields=proc.pid:proc.pid user.loginname:user.loginname dkey:bar proc.args:proc.args proc.cmdline:proc.cmdline user.loginuid:user.loginuid ckey:CValue akey:AValue bkey:BValue tags=process,mitre_privilege_escalation
CEF:0|Falcosecurity|Falco|1.0|Falco Event|K8s Service Deleted|3|uuid=9dcfc783-aee7-4370-b355-aec3b0df6e16 start=2022-11-29T15:35:56Z msg=K8s Service Deleted (user=%ka.user.name service=%ka.target.name ns=%ka.target.namespace resource=%ka.target.resource resp=%ka.response.code decision=%ka.auth.decision reason=%ka.auth.reason) source=k8s_audit outputfields=ka.response.code:ka.response.code ka.target.name:ka.target.name ckey:CValue akey:AValue ka.user.name:ka.user.name bkey:BValue dkey:bar ka.auth.decision:ka.auth.decision ka.auth.reason:ka.auth.reason ka.target.namespace:ka.target.namespace ka.target.resource:ka.target.resource tags=k8s
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Packet socket created in container|4|uuid=6a454010-b8cf-43f2-a751-8d64cbe8934e start=2022-11-29T15:36:05Z msg=Packet socket was created in a container (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid socket_info=%evt.args container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag) source=syscalls outputfields=container.id:container.id k8s.pod.name:k8s.pod.name proc.pid:proc.pid container.name:container.name user.name:user.name dkey:bar bkey:BValue proc.cmdline:proc.cmdline user.loginuid:user.loginuid ckey:CValue k8s.ns.name:k8s.ns.name akey:AValue container.image.repository:container.image.repository container.image.tag:container.image.tag evt.args:evt.args tags=network,mitre_discovery
CEF:0|Falcosecurity|Falco|1.0|Falco Event|CloudTrail Logging Disabled|6|uuid=2b484d90-c738-44b9-8861-cc1835f75666 start=2022-11-29T15:36:19Z msg=The CloudTrail logging has been disabled. (requesting user=%ct.user, requesting IP=%ct.srcip, AWS region=%ct.region, resource name=%ct.request.name) source=cloudtrail outputfields=ct.srcip:ct.srcip ct.user:ct.user ckey:CValue akey:AValue bkey:BValue dkey:bar ct.region:ct.region ct.request.name:ct.request.name tags=cloud,aws,aws_cloudtrail
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Attach/Exec Pod|4|uuid=bc4ea637-ba19-4be9-8ed9-54d6a3531320 start=2022-11-29T15:36:24Z msg=Attach/Exec to pod (user=%ka.user.name pod=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace action=%ka.target.subresource command=%ka.uri.param[command]) source=k8s_audit outputfields=ka.target.name:ka.target.name ka.uri.param:ka.uri.param ka.user.name:ka.user.name bkey:BValue dkey:bar ka.target.namespace:ka.target.namespace ka.target.resource:ka.target.resource ka.target.subresource:ka.target.subresource akey:AValue ckey:CValue tags=k8s
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Linux Kernel Module Injection Detected|6|uuid=5e9c4570-2801-416e-8218-eb05ee58b558 start=2022-11-29T15:36:30Z msg=Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args %container.info image=%container.image.repository:%container.image.tag) source=syscalls outputfields=akey:AValue bkey:BValue dkey:bar container.image.repository:container.image.repository container.image.tag:container.image.tag container.info:container.info proc.pname:proc.pname user.name:user.name proc.args:proc.args user.loginuid:user.loginuid ckey:CValue tags=process
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Console Login Without MFA|8|uuid=872f2ef6-74cc-495a-9f85-a42b565126a7 start=2022-11-29T15:36:36Z msg=Detected a console login without MFA (requesting user=%ct.user, requesting IP=%ct.srcip, AWS region=%ct.region) source=cloudtrail outputfields=ct.user:ct.user akey:AValue bkey:BValue ckey:CValue dkey:bar ct.region:ct.region ct.srcip:ct.srcip tags=cloud,aws,aws_console,aws_iam
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Unexpected UDP Traffic|4|uuid=ab16bc41-f672-44bb-b8a9-66ae538d77fd start=2022-11-29T15:36:54Z msg=Unexpected UDP Traffic Seen (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid connection=%fd.name proto=%fd.l4proto evt=%evt.type %evt.args container_id=%container.id image=%container.image.repository)
 source=syscalls outputfields=fd.l:fd.l fd.name:fd.name akey:AValue dkey:bar proc.cmdline:proc.cmdline proc.pid:proc.pid ckey:CValue bkey:BValue container.id:container.id evt.args:evt.args evt.type:evt.type user.loginuid:user.loginuid user.name:user.name container.image.repository:container.image.repository tags=network,mitre_exfiltration
CEF:0|Falcosecurity|Falco|1.0|Falco Event|User has been moved from suspended status in OKTA.|4|uuid=9eaf0c47-4ed0-48e2-b4a8-75eb32275e35 start=2022-11-29T15:37:01Z msg=A user has been moved from suspended status in OKTA (user=%okta.actor.name, ip=%okta.client.ip, target user=%okta.target.user.name) source=okta outputfields=okta.client.ip:okta.client.ip okta.target.user:okta.target.user ckey:CValue akey:AValue bkey:BValue dkey:bar okta.actor.name:okta.actor.name tags=okta
CEF:0|Falcosecurity|Falco|1.0|Falco Event|Delete Bucket Public Access Block|8|uuid=809177dc-6901-4265-a1e4-5a71089063f8 start=2022-11-29T15:37:09Z msg=A public access block for a bucket has been deleted (requesting user=%ct.user, requesting IP=%ct.srcip, AWS region=%ct.region, bucket=%s3.bucket) source=cloudtrail outputfields=ct.user:ct.user ckey:CValue akey:AValue bkey:BValue dkey:bar ct.region:ct.region ct.srcip:ct.srcip tags=cloud,aws,aws_s3
CEF:0|Falcosecurity|Falco|1.0|Falco Event|User accessing OKTA admin section|4|uuid=47001f54-44ad-4e9f-a516-386106e17ab5 start=2022-11-29T15:37:24Z msg=A user accessed the OKTA admin section of your OKTA instance (user=%okta.actor.name, ip=%okta.client.ip) source=okta outputfields=ckey:CValue akey:AValue dkey:bar okta.actor.name:okta.actor.name okta.client.ip:okta.client.ip bkey:BValue tags=okta
CEF:0|Falcosecurity|Falco|1.0|Falco Event|System procs network activity|4|uuid=aa29dfc5-98d9-478d-803f-15d538f34708 start=2022-11-29T15:37:32Z msg=Known system binary sent/received network traffic (user=%user.name user_loginuid=%user.loginuid command=%proc.cmdline pid=%proc.pid connection=%fd.name container_id=%container.id image=%container.image.repository)
 source=syscalls outputfields=fd.name:fd.name ckey:CValue dkey:bar user.loginuid:user.loginuid user.name:user.name akey:AValue bkey:BValue container.id:container.id container.image.repository:container.image.repository proc.cmdline:proc.cmdline proc.pid:proc.pid tags=network,mitre_exfiltration
```

**Which issue(s) this PR fixes**:

#382 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


