### PR TITLE
Replace circleci to use gh actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   default:
     docker:
-    - image: cimg/go:1.18.1
+    - image: cimg/go:1.20.2
 
 install_buildx: &install_buildx
   name: Install Docker buildx
@@ -74,20 +74,6 @@ install_syft: &install_syft
     syft version
 
 jobs:
-  lint:
-    executor:
-      name: default
-    steps:
-    - checkout
-    - run: make lint
-
-  test:
-    executor:
-      name: default
-    steps:
-    - checkout
-    - run: make test
-
   build-image:
     executor:
       name: default
@@ -109,72 +95,6 @@ jobs:
           make goreleaser-snapshot
           docker images
           docker run falcosecurity/falcosidekick:latest-amd64 --version
-
-  build-push-main:
-    executor:
-      name: default
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-    steps:
-    - checkout
-    - setup_remote_docker
-    - run: *install_buildx
-    - run: *setup_docker_multiarch
-    - run: *install_goreleaser
-    - run: *install_cosign
-    - run: *install_syft
-    - run:
-        no_output_timeout: 30m
-        command: |
-          make goreleaser-snapshot
-          docker run falcosecurity/falcosidekick:latest-amd64 --version
-    - run:
-        name: Push image to Dockerhub
-        no_output_timeout: 30m
-        command: |
-          echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-          docker push falcosecurity/falcosidekick:latest-amd64
-          docker push falcosecurity/falcosidekick:latest-arm64
-          docker push falcosecurity/falcosidekick:latest-armv7
-          docker manifest create --amend falcosecurity/falcosidekick:latest falcosecurity/falcosidekick:latest-amd64 \
-            falcosecurity/falcosidekick:latest-arm64 falcosecurity/falcosidekick:latest-armv7
-          docker manifest push --purge falcosecurity/falcosidekick:latest
-
-  build-push-ecr:
-    executor:
-      name: default
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
-    steps:
-    - checkout
-    - setup_remote_docker
-    - run: *install_buildx
-    - run: *setup_docker_multiarch
-    - run: *install_goreleaser
-    - run: *install_awscli
-    - run: *install_cosign
-    - run: *install_syft
-    - run:
-        no_output_timeout: 30m
-        command: |
-          make goreleaser-snapshot
-          docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --version
-    - run:
-        name: Push image to AWS ECR
-        no_output_timeout: 30m
-        command: |
-          aws ecr-public get-login-password --region us-east-1 | \
-            docker login --username AWS --password-stdin public.ecr.aws/falcosecurity
-          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-amd64
-          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-arm64
-          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-armv7
-          docker manifest create --amend public.ecr.aws/falcosecurity/falcosidekick:latest public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 \
-            public.ecr.aws/falcosecurity/falcosidekick:latest-arm64 public.ecr.aws/falcosecurity/falcosidekick:latest-armv7
-          docker manifest push --purge public.ecr.aws/falcosecurity/falcosidekick:latest
 
   release:
     executor:
@@ -206,47 +126,18 @@ jobs:
 workflows:
   main:
     jobs:
-      - test:
-          filters:
-            tags:
-              only: /(v)?[0-9]+(\.[0-9]+)*(-.*)*/
-      - lint:
-          filters:
-            tags:
-              only: /(v)?[0-9]+(\.[0-9]+)*(-.*)*/
       - build-image:
-          requires:
-            - test
-            - lint
           filters:
             branches:
               ignore: master
             tags:
               only: /(v)?[0-9]+(\.[0-9]+)*(-.*)*/
-      - build-push-main:
-          context: falco
-          requires:
-            - test
-            - lint
-          filters:
-            branches:
-              only: master
-      - build-push-ecr:
-          context: test-infra
-          requires:
-            - test
-            - lint
-          filters:
-            branches:
-              only: master
       - release:
           context:
             - falco
             - test-infra
             - cosign
           requires:
-            - test
-            - lint
             - build-image
           filters:
             branches:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "release-note-none"
+      - "ok-to-test"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,37 @@
+name: build-ci-images
+
+on:
+  pull_request:
+
+jobs:
+  build-image:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.20'
+          check-latest: true
+          cache: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      - uses: anchore/sbom-action/download-syft@07978da4bdb4faa726e52dfc6b1bed63d4b56479 # v0.13.3
+
+      - uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        with:
+          install-only: true
+
+      - name: run goreleaser-snapshot
+        run: |
+          make goreleaser-snapshot
+          docker images
+          docker run falcosecurity/falcosidekick:latest-amd64 --version
+          docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.20'
+          check-latest: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+        with:
+          version: v1.51
+          args: --timeout=5m

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,0 +1,80 @@
+name: push-ci-images
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-push-image:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.20'
+          check-latest: true
+          cache: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
+
+      - uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # v3.0.1
+
+      - uses: anchore/sbom-action/download-syft@07978da4bdb4faa726e52dfc6b1bed63d4b56479 # v0.13.3
+
+      - uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        with:
+          install-only: true
+
+      - name: run goreleaser-snapshot
+        run: |
+          make goreleaser-snapshot
+          docker images
+          docker run falcosecurity/falcosidekick:latest-amd64 --version
+          docker run public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 --version
+
+      # Push images to DockerHUB
+      - name: Login to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push images to Dockerhub
+        run: |
+          docker push falcosecurity/falcosidekick:latest-amd64
+          docker push falcosecurity/falcosidekick:latest-arm64
+          docker push falcosecurity/falcosidekick:latest-armv7
+          docker manifest create --amend falcosecurity/falcosidekick:latest falcosecurity/falcosidekick:latest-amd64 \
+            falcosecurity/falcosidekick:latest-arm64 falcosecurity/falcosidekick:latest-armv7
+          docker manifest push --purge falcosecurity/falcosidekick:latest
+
+      # Push images to AWS Public ECR
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::292999226676:role/github_actions-falcosidekick-ecr
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
+        with:
+          registry-type: public
+
+      - run: |
+          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-amd64
+          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-arm64
+          docker push public.ecr.aws/falcosecurity/falcosidekick:latest-armv7
+          docker manifest create --amend public.ecr.aws/falcosecurity/falcosidekick:latest public.ecr.aws/falcosecurity/falcosidekick:latest-amd64 \
+            public.ecr.aws/falcosecurity/falcosidekick:latest-arm64 public.ecr.aws/falcosecurity/falcosidekick:latest-armv7
+          docker manifest push --purge public.ecr.aws/falcosecurity/falcosidekick:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  unit-tests:
+    name: Run unit tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: '1.20'
+          check-latest: true
+          cache: true
+      - name: Run Go tests
+        run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.15
+ARG BASE_IMAGE=alpine:3.17
 # Final Docker image
 FROM ${BASE_IMAGE} AS final-stage
 LABEL MAINTAINER "Thomas Labarussias <issif+falcosidekick@gadz.org>"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=golang:1.18-buster
-ARG BASE_IMAGE=alpine:3.15
+ARG BUILDER_IMAGE=golang:1.20-bullseye
+ARG BASE_IMAGE=alpine:3.17
 
 FROM ${BUILDER_IMAGE} AS build-stage
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       - "1025:1025"
       - "8025:8025"
     profiles: [smtp]
-  
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0
     ports:
@@ -18,7 +18,7 @@ services:
       - xpack.security.enabled=false
       - xpack.security.transport.ssl.enabled=false
     profiles: [elasticsearch]
-  
+
   nats:
     image: nats:latest
     ports:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/falcosecurity/falcosidekick
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go/functions v1.5.0
@@ -22,6 +22,7 @@ require (
 	github.com/nats-io/nats.go v1.16.0
 	github.com/nats-io/stan.go v0.10.3
 	github.com/prometheus/client_golang v1.13.0
+	github.com/redis/go-redis/v9 v9.0.2
 	github.com/segmentio/kafka-go v0.4.38
 	github.com/spf13/viper v1.12.0
 	github.com/streadway/amqp v1.0.0
@@ -112,7 +113,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/redis/go-redis/v9 v9.0.2 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,13 +204,14 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
+github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/caio/go-tdigest v3.1.0+incompatible h1:uoVMJ3Q5lXmVLCCqaMGHLBWnbGoN6Lpu7OAUPR60cds=
 github.com/caio/go-tdigest v3.1.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -836,7 +837,6 @@ github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1Sd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -849,7 +849,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=


### PR DESCRIPTION
**What type of PR is this?**


/kind cleanup
/kind feature

**Any specific area of the project related to this PR?**
/area build

**What this PR does / why we need it**:
- Replace CircleCI to GitHub actions

This is the first PR to replace CircleCI to use GitHub actions, we already discussed this in slack.

This PR introduces the following things:
- add GitHub actions to test, lint, build images and push images to docker hub and aws ecr.

- the push images will happen only when we merge a PR
- During a PR we will test, lint and run goreleaser snapshot to check if everything is good.


- Also this update go to 1.20
- bump alpine image to use latest available
- and add dependabot config

There are other improvements that we can do, but will do in a follow up to make the PR smaller
also the next is to move the release job, which I will do after we merge this PR and validate that we can push images

/assign @LucaGuerra @leogr @Issif 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


