### PR TITLE
feat(prometheus-hostname): adding hostname from playload as label of prom events metric

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -131,6 +131,10 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	nullClient.CountMetric("falco.accepted", 1, []string{"priority:" + falcopayload.Priority.String()})
 	stats.Falco.Add(strings.ToLower(falcopayload.Priority.String()), 1)
 	promLabels := map[string]string{"rule": falcopayload.Rule, "priority": falcopayload.Priority.String(), "k8s_ns_name": kn, "k8s_pod_name": kp}
+	if falcopayload.Hostname != "" {
+		promLabels["hostname"] = falcopayload.Hostname
+	}
+
 	for key, value := range config.Customfields {
 		if regPromLabels.MatchString(key) {
 			promLabels[key] = value


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

The Sidekick doesn't give the hostname to the prom metrics leading to monitoring a simple global count of event when used outside of Kubernetes nodes.


**Which issue(s) this PR fixes**:

None
