### PR TITLE
fix: timescaledb hypertablename config

### DIFF
--- a/config.go
+++ b/config.go
@@ -399,7 +399,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("TimescaleDB.User", "postgres")
 	v.SetDefault("TimescaleDB.Password", "postgres")
 	v.SetDefault("TimescaleDB.Database", "falcosidekick")
-	v.SetDefault("TimescaleDB.Hypertable", "falcosidekick_events")
+	v.SetDefault("TimescaleDB.HypertableName", "falcosidekick_events")
 	v.SetDefault("TimescaleDB.MinimumPriority", "")
 
 	v.SetDefault("Redis.Address", "")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

This fixes an error that occurs when using the TimescaleDB output:
`[ERROR] : TimescaleDB - ERROR: syntax error at or near "(" (SQLSTATE 42601)`.

Turns out because of the config typo fixed in this PR, this [line](https://github.com/falcosecurity/falcosidekick/blob/master/outputs/timescaledb.go#L45) results in an empty string table name and causes the SQL error.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


