### PR TITLE
add hostname as prom label for cardinality

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -71,7 +71,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 
 // testHandler sends a test event to all enabled outputs.
 func testHandler(w http.ResponseWriter, r *http.Request) {
-	r.Body = io.NopCloser(bytes.NewReader([]byte(`{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule", "time":"` + time.Now().UTC().Format(time.RFC3339) + `","output_fields": {"proc.name":"falcosidekick","user.name":"falcosidekick"}, "tags":["test","example"]}`)))
+	r.Body = io.NopCloser(bytes.NewReader([]byte(`{"output":"This is a test from falcosidekick","priority":"Debug","hostname": "falcosidekick", "rule":"Test rule", "time":"` + time.Now().UTC().Format(time.RFC3339) + `","output_fields": {"proc.name":"falcosidekick","user.name":"falcosidekick"}, "tags":["test","example"]}`)))
 	mainHandler(w, r)
 }
 

--- a/stats_prometheus.go
+++ b/stats_prometheus.go
@@ -41,6 +41,7 @@ func getOutputNewCounterVec() *prometheus.CounterVec {
 func getFalcoNewCounterVec(config *types.Configuration) *prometheus.CounterVec {
 	regPromLabels, _ := regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
 	labelnames := []string{
+		"hostname",
 		"rule",
 		"priority",
 		"k8s_ns_name",

--- a/stats_prometheus_test.go
+++ b/stats_prometheus_test.go
@@ -16,11 +16,11 @@ func TestFalcoNewCounterVec(t *testing.T) {
 	c.Customfields["should*fail"] = "bar"
 
 	cv := getFalcoNewCounterVec(c)
-	shouldbe := []string{"rule", "priority", "k8s_ns_name", "k8s_pod_name", "test"}
+	shouldbe := []string{"hostname", "rule", "priority", "k8s_ns_name", "k8s_pod_name", "test"}
 	mm, err := cv.GetMetricWithLabelValues(shouldbe...)
 	if err != nil {
 		t.Errorf("Error getting Metrics from promauto")
 	}
 	metricDescString := mm.Desc().String()
-	require.Equal(t, metricDescString, "Desc{fqName: \"falco_events\", help: \"\", constLabels: {}, variableLabels: [rule priority k8s_ns_name k8s_pod_name test]}")
+	require.Equal(t, metricDescString, "Desc{fqName: \"falco_events\", help: \"\", constLabels: {}, variableLabels: [hostname rule priority k8s_ns_name k8s_pod_name test]}")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Fix cardinality issue with Prometheus metrics
```
2023/03/21 13:14:00 http: panic serving 127.0.0.1:46890: inconsistent label cardinality: expected 9 label values but got 10 in prometheus.Labels{"bkey":"BValue", "ckey":"CValue", "fd_name":"", "hostname":"falco-rkvpv", "k8s_ns_name":"falco1", "k8s_pod_name":"falco-rkvpv", "priority":"Notice", "proc_name":"bash", "rule":"Terminal shell in container", "user_name":"root"}
```


**Which issue(s) this PR fixes**:

Bug introduced by #420 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


