### PR TITLE
fix panic with assertion when the value of the output fields are nil …

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -103,11 +103,13 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	var kn, kp string
 	for i, j := range falcopayload.OutputFields {
-		if i == "k8s.ns.name" {
-			kn = j.(string)
-		}
-		if i == "k8s.pod.name" {
-			kp = j.(string)
+		if j != nil {
+			if i == "k8s.ns.name" {
+				kn = j.(string)
+			}
+			if i == "k8s.pod.name" {
+				kp = j.(string)
+			}
 		}
 	}
 


### PR DESCRIPTION
…and not interface{}

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

fix panic with assertion when the value of the output fields are nil and not interface{}

```
2023/03/23 13:30:43 http: panic serving 127.0.0.1:45414: interface conversion: interface {} is nil, not string
goroutine 74183 [running]:
net/http.(*conn).serve.func1()
	$GOROOT/src/net/http/server.go:1854 +0xbf
panic({0x21f5840, 0xc000a163c0})
	$GOROOT/src/runtime/panic.go:890 +0x263
main.newFalcoPayload({0x7f2a4bdee318?, 0xc0006d8200})
	/home/runner/work/falcosidekick/falcosidekick/handlers.go:107 +0x1509
main.mainHandler({0x2b1d0f0, 0xc0001b28c0}, 0xc000564200)
	/home/runner/work/falcosidekick/falcosidekick/handlers.go:43 +0x286
net/http.HandlerFunc.ServeHTTP(0xc0001b28c0?, {0x2b1d0f0?, 0xc0001b28c0?}, 0x2572cf4?)
	$GOROOT/src/net/http/server.go:2122 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0?, {0x2b1d0f0, 0xc0001b28c0}, 0xc000564200)
	$GOROOT/src/net/http/server.go:2500 +0x149
net/http.serverHandler.ServeHTTP({0x2b0e708?}, {0x2b1d0f0, 0xc0001b28c0}, 0xc000564200)
	$GOROOT/src/net/http/server.go:2936 +0x316
net/http.(*conn).serve(0xc0001361b0, {0x2b1e178, 0xc0007a8b10})
	$GOROOT/src/net/http/server.go:1995 +0x612
created by net/http.(*Server).Serve
	$GOROOT/src/net/http/server.go:3089 +0x5ed
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


