### PR TITLE
feat(severity-priority): match the priority with alertmanager severity label

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ alertmanager:
   # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
   # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2
   # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2
+  # customseveritymap: "" # comma separated list of tuple composed of a ':' separated Falco priority and Alertmanager severity that is used to override the severity label associated to the priority level of falco event. Example: debug:value_1,critical:value2.  Default mapping (priority:severity): emergency:critical|alert:critical|critical:critical|error:warning|warning:warning|notice:information|informational:information|debug:information
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
@@ -766,6 +767,11 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   added to the Alerts. Example: `my_label_1:my_value_1, my_label_1:my_value_2` (default: `""`)
 - **ALERTMANAGER_EXTRAANNOTATIONS** : comma separated list of annotations composed of a ':' separated name and
   value that is added to the Alerts. Example: `my_annotation_1:my_value_1, my_annotation_1:my_value_2` (default: `""`)
+- **ALERTMANAGER_CUSTOMSEVERITYMAP** : comma separated list of tuple composed of a ':' separated Falco priority and
+  Alertmanager severity that is used to override the severity label associated to the priority level of falco event.
+  Example: `debug:value_1,critical:value2`. 
+  Default mapping (priority:severity): `emergency:critical|alert:critical|critical:critical|error:warning|warning:warning|notice:information|informational:information|debug:information`.
+  (default: `""`)
 - **ELASTICSEARCH_HOSTPORT** : Elasticsearch http://host:port, if not `empty`,
   Elasticsearch is _enabled_
 - **ELASTICSEARCH_INDEX** : Elasticsearch index (default: falco)

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ alertmanager:
   # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
   # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2
   # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2
-  # customseveritymap: "" # comma separated list of tuple composed of a ':' separated Falco priority and Alertmanager severity that is used to override the severity label associated to the priority level of falco event. Example: debug:value_1,critical:value2.  Default mapping (priority:severity): emergency:critical|alert:critical|critical:critical|error:warning|warning:warning|notice:information|informational:information|debug:information
+  # customseveritymap: "" # comma separated list of tuple composed of a ':' separated Falco priority and Alertmanager severity that is used to override the severity label associated to the priority level of falco event. Example: debug:value_1,critical:value2.  Default mapping (priority:severity): emergency:critical,alert:critical,critical:critical,error:warning,warning:warning,notice:information,informational:information,debug:information
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled
@@ -769,9 +769,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
   value that is added to the Alerts. Example: `my_annotation_1:my_value_1, my_annotation_1:my_value_2` (default: `""`)
 - **ALERTMANAGER_CUSTOMSEVERITYMAP** : comma separated list of tuple composed of a ':' separated Falco priority and
   Alertmanager severity that is used to override the severity label associated to the priority level of falco event.
-  Example: `debug:value_1,critical:value2`. 
-  Default mapping (priority:severity): `emergency:critical|alert:critical|critical:critical|error:warning|warning:warning|notice:information|informational:information|debug:information`.
-  (default: `""`)
+  Example: `debug:value_1,critical:value2`. Default mapping (priority:severity): `emergency:critical,alert:critical,critical:critical,error:warning,warning:warning,notice:information,informational:information,debug:information` (default: `""`)
 - **ELASTICSEARCH_HOSTPORT** : Elasticsearch http://host:port, if not `empty`,
   Elasticsearch is _enabled_
 - **ELASTICSEARCH_INDEX** : Elasticsearch index (default: falco)

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ func getConfig() *types.Configuration {
 		Elasticsearch:   types.ElasticsearchOutputConfig{CustomHeaders: make(map[string]string)},
 		OpenObserve:     types.OpenObserveConfig{CustomHeaders: make(map[string]string)},
 		Webhook:         types.WebhookOutputConfig{CustomHeaders: make(map[string]string)},
-		Alertmanager:    types.AlertmanagerOutputConfig{ExtraLabels: make(map[string]string), ExtraAnnotations: make(map[string]string), CustomSeverityMap: make(map[string]string)},
+		Alertmanager:    types.AlertmanagerOutputConfig{ExtraLabels: make(map[string]string), ExtraAnnotations: make(map[string]string), CustomSeverityMap: make(map[types.PriorityType]string)},
 		CloudEvents:     types.CloudEventsOutputConfig{Extensions: make(map[string]string)},
 		GCP:             types.GcpOutputConfig{PubSub: types.GcpPubSub{CustomAttributes: make(map[string]string)}},
 	}
@@ -575,11 +575,12 @@ func getConfig() *types.Configuration {
 		severitymap := strings.Split(value, ",")
 		for _, severitymatch := range severitymap {
 			priorityString, severityValue, found := strings.Cut(severitymatch, ":")
-			if types.Priority(priorityString) == types.Default {
+			priority := types.Priority(priorityString)
+			if priority == types.Default {
 				log.Printf("[ERROR] : AlertManager - Priority '%v' is not a valid falco priority level", priorityString)
 				continue
 			} else if found {
-				c.Alertmanager.CustomSeverityMap[priorityString] = strings.TrimSpace(severityValue)
+				c.Alertmanager.CustomSeverityMap[priority] = strings.TrimSpace(severityValue)
 			} else {
 				log.Printf("[ERROR] : AlertManager - No severity given to '%v' (tuple extracted: '%v')", priorityString, severitymatch)
 			}

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -70,8 +70,9 @@ alertmanager:
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # endpoint: "" # alertmanager endpoint for posting alerts: "/api/v1/alerts" or "/api/v2/alerts" (default: "/api/v1/alerts")
   # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
-  # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2
-  # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2
+  # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2 (default: "")
+  # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2 (default: "")
+  # customseveritymap: "" # comma separated list of tuple composed of a ':' separated Falco priority and Alertmanager severity that is used to override the severity label associated to the priority level of falco event. Example: debug:value_1,critical:value2. Default mapping: emergency:critical|alert:critical|critical:critical|error:warning|warning:warning|notice:information|informational:information|debug:information. (default: "")
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -72,7 +72,7 @@ alertmanager:
   # expiresafter: "" if set to a non-zero value, alert expires after that time in seconds (default: 0)
   # extralabels: "" # comma separated list of labels composed of a ':' separated name and value that is added to the Alerts. Example: my_label_1:my_value_1, my_label_1:my_value_2 (default: "")
   # extraannotations: "" # comma separated list of annotations composed of a ':' separated name and value that is added to the Alerts. Example: my_annotation_1:my_value_1, my_annotation_1:my_value_2 (default: "")
-  # customseveritymap: "" # comma separated list of tuple composed of a ':' separated Falco priority and Alertmanager severity that is used to override the severity label associated to the priority level of falco event. Example: debug:value_1,critical:value2. Default mapping: emergency:critical|alert:critical|critical:critical|error:warning|warning:warning|notice:information|informational:information|debug:information. (default: "")
+  # customseveritymap: "" # comma separated list of tuple composed of a ':' separated Falco priority and Alertmanager severity that is used to override the severity label associated to the priority level of falco event. Example: debug:value_1,critical:value2. Default mapping: emergency:critical,alert:critical,critical:critical,error:warning,warning:warning,notice:information,informational:information,debug:information. (default: "")
 
 elasticsearch:
   # hostport: "" # http://{domain or ip}:{port}, if not empty, Elasticsearch output is enabled

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -93,7 +93,7 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 
 	amPayload.Labels["priority"] = falcopayload.Priority.String()
 
-	if val, ok := config.Alertmanager.CustomSeverityMap[falcopayload.Priority.String()]; ok {
+	if val, ok := config.Alertmanager.CustomSeverityMap[falcopayload.Priority]; ok {
 		amPayload.Labels["severity"] = val
 	} else {
 		amPayload.Labels["severity"] = defaultSeverityMap[falcopayload.Priority]

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -16,6 +16,17 @@ type alertmanagerPayload struct {
 	EndsAt      time.Time         `json:"endsAt,omitempty"`
 }
 
+var defaultSeverityMap = map[types.PriorityType]string{
+	types.Debug:         "information",
+	types.Informational: "information",
+	types.Notice:        "information",
+	types.Warning:       "warning",
+	types.Error:         "warning",
+	types.Critical:      "critical",
+	types.Alert:         "critical",
+	types.Emergency:     "critical",
+}
+
 func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Configuration) []alertmanagerPayload {
 	var amPayload alertmanagerPayload
 	amPayload.Labels = make(map[string]string)
@@ -81,6 +92,13 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 	}
 
 	amPayload.Labels["priority"] = falcopayload.Priority.String()
+
+	if val, ok := config.Alertmanager.CustomSeverityMap[falcopayload.Priority.String()]; ok {
+		amPayload.Labels["severity"] = val
+	} else {
+		amPayload.Labels["severity"] = defaultSeverityMap[falcopayload.Priority]
+	}
+
 	amPayload.Annotations["info"] = falcopayload.Output
 	amPayload.Annotations["description"] = falcopayload.Output
 	amPayload.Annotations["summary"] = falcopayload.Rule

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewAlertmanagerPayloadO(t *testing.T) {
-	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","proc_tty":"1234","eventsource":"syscalls","hostname":"test-host","rule":"Test rule","source":"falco","tags":"test,example"},"annotations":{"info":"This is a test from falcosidekick","description":"This is a test from falcosidekick","summary":"Test rule"}}]`
+	expectedOutput := `[{"labels":{"proc_name":"falcosidekick","priority":"Debug","severity": "information","proc_tty":"1234","eventsource":"syscalls","hostname":"test-host","rule":"Test rule","source":"falco","tags":"test,example"},"annotations":{"info":"This is a test from falcosidekick","description":"This is a test from falcosidekick","summary":"Test rule"}}]`
 	var f types.FalcoPayload
 	d := json.NewDecoder(strings.NewReader(falcoTestInput))
 	d.UseNumber()

--- a/types/types.go
+++ b/types/types.go
@@ -224,7 +224,8 @@ type AlertmanagerOutputConfig struct {
 	Endpoint         string
 	ExpiresAfter     int
 	ExtraLabels      map[string]string
-	ExtraAnnotations map[string]string
+	ExtraAnnotations  map[string]string
+	CustomSeverityMap map[string]string
 }
 
 type ElasticsearchOutputConfig struct {

--- a/types/types.go
+++ b/types/types.go
@@ -217,13 +217,13 @@ type DiscordOutputConfig struct {
 }
 
 type AlertmanagerOutputConfig struct {
-	HostPort         string
-	MinimumPriority  string
-	CheckCert        bool
-	MutualTLS        bool
-	Endpoint         string
-	ExpiresAfter     int
-	ExtraLabels      map[string]string
+	HostPort          string
+	MinimumPriority   string
+	CheckCert         bool
+	MutualTLS         bool
+	Endpoint          string
+	ExpiresAfter      int
+	ExtraLabels       map[string]string
 	ExtraAnnotations  map[string]string
 	CustomSeverityMap map[string]string
 }

--- a/types/types.go
+++ b/types/types.go
@@ -225,7 +225,7 @@ type AlertmanagerOutputConfig struct {
 	ExpiresAfter      int
 	ExtraLabels       map[string]string
 	ExtraAnnotations  map[string]string
-	CustomSeverityMap map[string]string
+	CustomSeverityMap map[PriorityType]string
 }
 
 type ElasticsearchOutputConfig struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area config

/area outputs

**What this PR does / why we need it**:

Automatch the priority of a falco alert into a severity label.
There is a configuration options built to over the default map if the priority is found in this config map. Otherwise, we use the default.
The configuration checks if the indicated priority is a valid one.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

I'll update the docs once the feature is validated and fully dev.

