### PR TITLE
fix: alertmanager: validate labels and annotation names only, not values

### DIFF
--- a/config.go
+++ b/config.go
@@ -496,41 +496,33 @@ func getConfig() *types.Configuration {
 			}
 		}
 	}
-	regex, _ := regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+
+	promKVNameRegex, _ := regexp.Compile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+
 	if value, present := os.LookupEnv("ALERTMANAGER_EXTRALABELS"); present {
-		extralabels := strings.Split(value, ",")
-		for _, labelData := range extralabels {
-			if !regex.MatchString(labelData) {
-				log.Printf("[ERROR] : AlertManager - Extra field '%v' is not a valid prometheus labelData", labelData)
-				continue
-			}
-			values := strings.SplitN(labelData, ":", 2)
-			label := strings.TrimSpace(values[0])
-			if !regex.MatchString(label) {
-				log.Printf("[ERROR] : AlertManager - Extra field '%v' is not a valid prometheus label", label)
-				continue
-			}
-			if len(values) == 2 {
-				c.Alertmanager.ExtraLabels[label] = strings.TrimSpace(values[1])
+		extraLabels := strings.Split(value, ",")
+		for _, labelData := range extraLabels {
+			labelName, labelValue, found := strings.Cut(labelData, ":")
+			if !promKVNameRegex.MatchString(labelName) {
+				log.Printf("[ERROR] : AlertManager - Extra label name '%v' is not valid", labelName)
+			} else if found {
+				c.Alertmanager.ExtraLabels[labelName] = strings.TrimSpace(labelValue)
 			} else {
-				c.Alertmanager.ExtraLabels[label] = ""
+				c.Alertmanager.ExtraLabels[labelName] = ""
 			}
 		}
 	}
 
 	if value, present := os.LookupEnv("ALERTMANAGER_EXTRAANNOTATIONS"); present {
-		extraannotations := strings.Split(value, ",")
-		for _, annotationData := range extraannotations {
-			values := strings.SplitN(annotationData, ":", 2)
-			annotation := strings.TrimSpace(values[0])
-			if !regex.MatchString(annotation) {
-				log.Printf("[ERROR] : AlertManager - Extra field '%v' is not a valid prometheus annotation", annotation)
-				continue
-			}
-			if len(values) == 2 {
-				c.Alertmanager.ExtraAnnotations[annotation] = strings.TrimSpace(values[1])
+		extraAnnotations := strings.Split(value, ",")
+		for _, annotationData := range extraAnnotations {
+			annotationName, annotationValue, found := strings.Cut(annotationData, ":")
+			if !promKVNameRegex.MatchString(annotationName) {
+				log.Printf("[ERROR] : AlertManager - Extra annotation name '%v' is not valid", annotationName)
+			} else if found {
+				c.Alertmanager.ExtraAnnotations[annotationName] = strings.TrimSpace(annotationValue)
 			} else {
-				c.Alertmanager.ExtraAnnotations[annotation] = ""
+				c.Alertmanager.ExtraAnnotations[annotationName] = ""
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area config

**What this PR does / why we need it**:

Only validate Prometheus Label **names** and Annotation **names** _instead of validating **values** as well_.
Internally, Alertmanager and Prometheus use the same data model to represent both labels and annotations,
and apply the same validation logic.

See official doc here : https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels, which mentions : 

> Label names may contain ASCII letters, numbers, as well as underscores. They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning with __ are reserved for internal use.
> 
> Label values may contain any Unicode characters.

As a practical example, we encountered an issue because we use dashes in our label values,
such that this was rejected : `extralabels: "cloud:aws,region:eu-west-1,team:platform"`

**Special notes for your reviewer**:

Hello, we are currently in the process of experimenting with this project for internal usage ; 
it looks quite promising, great work 💪 😄 

We encountered an issue when trying to use our standardized internal alert routing,
which should be fixed with these changes 🙏 

It wasn't obvious to me where to add a test for such a bug fix,
I may have missed something but could not find config validation tests
so I didn't add one for this specific use case, I hope that's okay.