### PR TITLE
fix SMTP AuthMechanism to disable SASL Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ aws:
 
 smtp:
   # hostport: "" # host:port address of SMTP server, if not empty, SMTP output is enabled
-  # authmechanism: "plain" # SASL Mechanisms : plain, oauthbearer, external, anonymous or "" (disable SASL). Default: plain
+  # authmechanism: "plain" # SASL Mechanisms : plain, oauthbearer, external, anonymous or none (disable SASL). Default: plain
   # user: "" # user for Plain Mechanism
   # password: "" # password for Plain Mechanism
   # token: "" # OAuthBearer token for OAuthBearer Mechanism
@@ -854,7 +854,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **SMTP_MINIMUMPRIORITY** : minimum priority of event for using this output,
   order is
   `emergency|alert|critical|error|warning|notice|informational|debug or "" (default)`
-- **SMTP_AUTHMECHANISM** : SASL Mechanisms `plain|oauthbearer|external|anonymous or "" (disable SASL)` Default to `plain`
+- **SMTP_AUTHMECHANISM** : SASL Mechanisms `plain|oauthbearer|external|anonymous or none (disable SASL)` Default to `plain`
 - **SMTP_USER** :  user for Plain Mechanism
 - **SMTP_PASSWORD** : password for Plain Mechanism
 - **SMTP_TOKEN** : # OAuthBearer token for OAuthBearer Mechanism

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -155,7 +155,7 @@ aws:
 
 smtp:
   # hostport: "" # host:port address of SMTP server, if not empty, SMTP output is enabled
-  # authmechanism: "plain" # SASL Mechanisms : plain, oauthbearer, external, anonymous or "" (disable SASL). Default: plain
+  # authmechanism: "plain" # SASL Mechanisms : plain, oauthbearer, external, anonymous or none (disable SASL). Default: plain
   # user: "" # user for Plain Mechanism
   # password: "" # password for Plain Mechanism
   # token: "" # OAuthBearer token for OAuthBearer Mechanism

--- a/outputs/smtp.go
+++ b/outputs/smtp.go
@@ -99,7 +99,7 @@ func (c *Client) ReportErr(message string, err error) {
 }
 
 func (c *Client) GetAuth() (sasl.Client, error) {
-	if c.Config.SMTP.AuthMechanism == "" {
+	if c.Config.SMTP.AuthMechanism == "none" {
 		return nil, nil
 	}
 	var authClient sasl.Client
@@ -137,7 +137,7 @@ func (c *Client) SendMail(falcopayload types.FalcoPayload) {
 
 	if c.Config.Debug {
 		log.Printf("[DEBUG] : SMTP payload : \nServer: %v\n%v\n%v\nSubject: %v\n", c.Config.SMTP.HostPort, sp.From, sp.To, sp.Subject)
-		if c.Config.SMTP.AuthMechanism != "" {
+		if c.Config.SMTP.AuthMechanism != "none" {
 			log.Printf("[DEBUG] : SMTP - SASL Auth : \nMechanisms: %v\nUser: %v\nToken: %v\nIdentity: %v\nTrace: %v\n", c.Config.SMTP.AuthMechanism, c.Config.SMTP.User, c.Config.SMTP.Token, c.Config.SMTP.Identity, c.Config.SMTP.Trace)
 		} else {
 			log.Printf("[DEBUG] : SMTP - SASL Auth : Disabled\n")


### PR DESCRIPTION
When I want to disable SASL Auth, I'm setting environment variable of `SMTP_AUTHMECHANISM`, to `""`, but  it doesn't work and defaults to `plain`, logs:
```
2023/06/08 09:50:06 [DEBUG] : SMTP - SASL Auth :
Mechanisms: plain
User:
Token:
Identity:
Trace:
```
/kind bug
/area outputs
