### PR TITLE
feat(config/server): Add option for TLS and mTLS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,13 @@ customfields: # custom fields are added to falco events, if the value starts wit
 templatedfields: # templated fields are added to falco events and metrics, it uses Go template + output_fields values
   # Dkey: '{{ or (index . "k8s.ns.labels.foo") "bar" }}'
 # bracketreplacer: "_" # if not empty, replace the brackets in keys of Output Fields
-mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls (default: "/etc/certs")
+mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs (default: "/etc/certs")
+tlsserver:
+  deploy: false # if true, TLS server will be deployed instead of HTTP
+  certfile: "/etc/certs/server.crt" # server certification file
+  keyfile: "/etc/certs/server.key" # server key
+  mutualtls: false # if true, mTLS server will be deployed instead of TLS, deploy also has to be true
+  cacertfile: "/etc/certs/ca.crt" # for client certification if mutualtls is true
 
 slack:
   webhookurl: "" # Slack WebhookURL (ex: https://hooks.slack.com/services/XXXX/YYYY/ZZZZ), if not empty, Slack output is enabled
@@ -643,6 +649,11 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **TEMPLATEDFIELDS** : templated fields are added to falco events and metrics, it uses Go template + output_fields values
 - **BRACKETREPLACER** : if not empty, the brackets in keys of Output Fields are replaced
 - **MUTUALTLSFILESPATH**: path which will be used to stored certs and key for mutual tls authentication (default: "/etc/certs")
+- **TLSSERVER_DEPLOY**: if _true_ TLS server will be deployed instead of HTTP
+- **TLSSERVER_CERTFILE**: server certification file for TLS Server (default: "/etc/certs/server.crt")
+- **TLSSERVER_KEYFILE**: server key file for TLS Server (default: "/etc/certs/server.key")
+- **TLSSERVER_MUTUALTLS**: if _true_ mTLS server will be deployed instead of TLS, deploy also has to be true
+- **TLSSERVER_CACERTFILE**: CA certification file for client certification (default: "/etc/certs/ca.crt")
 - **SLACK_WEBHOOKURL** : Slack Webhook URL (ex: https://hooks.slack.com/services/XXXX/YYYY/ZZZZ)
 - **SLACK_CHANNEL** : Slack Channel (optionnal)
 - **SLACK_FOOTER** : Slack footer

--- a/config.go
+++ b/config.go
@@ -46,6 +46,12 @@ func getConfig() *types.Configuration {
 	v.SetDefault("BracketReplacer", "")
 	v.SetDefault("MutualTlsFilesPath", "/etc/certs")
 
+	v.SetDefault("TLSServer.Deploy", false)
+	v.SetDefault("TLSServer.CertFile", "/etc/certs/server.crt")
+	v.SetDefault("TLSServer.KeyFile", "/etc/certs/server.key")
+	v.SetDefault("TLSServer.MutualTLS", false)
+	v.SetDefault("TLSServer.CaCertFile", "/etc/certs/ca.crt")
+
 	v.SetDefault("Slack.WebhookURL", "")
 	v.SetDefault("Slack.Footer", "https://github.com/falcosecurity/falcosidekick")
 	v.SetDefault("Slack.Username", "Falcosidekick")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -8,7 +8,13 @@ customfields: # custom fields are added to falco events and metrics, if the valu
 templatedfields: # templated fields are added to falco events and metrics, it uses Go template + output_fields values
   # Dkey: '{{ or (index . "k8s.ns.labels.foo") "bar" }}'
 # bracketreplacer: "_" # if not empty, the brackets in keys of Output Fields are replaced
-mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls (default: "/etc/certs")
+mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs (default: "/etc/certs")
+tlsserver:
+  deploy: false # if true, TLS server will be deployed instead of HTTP
+  certfile: "/etc/certs/server.crt" # server certification file
+  keyfile: "/etc/certs/server.key" # server key
+  mutualtls: false # if true, mTLS server will be deployed instead of TLS, deploy also has to be true
+  cacertfile: "/etc/certs/ca.crt" # for client certification if mutualtls is true
 
 
 slack:

--- a/main.go
+++ b/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -729,7 +732,40 @@ func main() {
 		IdleTimeout:       60 * time.Second,
 	}
 
-	if err := server.ListenAndServe(); err != nil {
-		log.Fatalf("[ERROR] : %v", err.Error())
+	if config.TLSServer.Deploy {
+		if config.TLSServer.MutualTLS {
+			if config.Debug {
+				log.Printf("[DEBUG] : running mTLS server")
+			}
+
+			caCert, err := ioutil.ReadFile(config.TLSServer.CaCertFile)
+			if err != nil {
+				log.Printf("[ERROR] : %v\n", err.Error())
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+
+			server.TLSConfig = &tls.Config{
+				ClientAuth: tls.RequireAndVerifyClientCert,
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+
+		if config.Debug && !config.TLSServer.MutualTLS {
+			log.Printf("[DEBUG] : running TLS server")
+		}
+
+		if err := server.ListenAndServeTLS(config.TLSServer.CertFile, config.TLSServer.KeyFile); err != nil {
+			log.Fatalf("[ERROR] : %v", err.Error())
+		}
+	} else {
+		if config.Debug {
+			log.Printf("[DEBUG] : running HTTP server")
+		}
+
+		if err := server.ListenAndServe(); err != nil {
+			log.Fatalf("[ERROR] : %v", err.Error())
+		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -48,6 +48,7 @@ func (f FalcoPayload) Check() bool {
 // Configuration is a struct to store configuration
 type Configuration struct {
 	MutualTLSFilesPath string
+	TLSServer          TLSServer
 	Debug              bool
 	ListenAddress      string
 	ListenPort         int
@@ -102,6 +103,15 @@ type Configuration struct {
 	Redis              RedisConfig
 	Telegram           TelegramConfig
 	N8N                N8NConfig
+}
+
+// TLSServer represents parameters for TLS Server
+type TLSServer struct {
+	Deploy     bool
+	CertFile   string
+	KeyFile    string
+	MutualTLS  bool
+	CaCertFile string
 }
 
 // SlackOutputConfig represents parameters for Slack


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area config

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**: Currently only HTTP server can be deployed. It would be more secure if we could deploy TLS or mutualTLS server if wanted.

**Which issue(s) this PR fixes**: https://github.com/falcosecurity/falcosidekick/issues/507

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
The logic for config is a bit different than the one already used. I decided to add 3 config options as full paths for the 3 files needed. I feel this way it's more customizable and does not collide with the `mutualtlsfilespath` config. Eg. this way we could set it to the same folder but different file names, or a different folder, or reuse the files completely. 


