### PR TITLE
fix SMTP output duplicate headers

### DIFF
--- a/outputs/smtp.go
+++ b/outputs/smtp.go
@@ -154,7 +154,7 @@ func (c *Client) SendMail(falcopayload types.FalcoPayload) {
 		smtpClient.Auth(auth)
 	}
 
-	body := sp.To + "\n" + sp.Subject + "\n" + sp.From + "\n" + sp.Body
+	body := sp.Subject + "\n" + sp.Body
 
 	if c.Config.Debug {
 		log.Printf("[DEBUG] : SMTP payload : \nServer: %v\n%v\n%v\nSubject: %v\n", c.Config.SMTP.HostPort, sp.From, sp.To, sp.Subject)


### PR DESCRIPTION
Currently, SMTP output will duplicate `To:`, `From:`, `Subject:` headers and due to that services like Gmail are blocking incoming emails. For example:

![image (39)](https://github.com/falcosecurity/falcosidekick/assets/15917655/dc3150b8-bf10-4209-8947-5bbc8e9a8cc3)

/kind bug
/area outputs

