### PR TITLE
initialise root CAs for kafka output

### DIFF
--- a/outputs/kafka.go
+++ b/outputs/kafka.go
@@ -34,7 +34,7 @@ func NewKafkaClient(config *types.Configuration, stats *types.Statistics, promSt
 		caCertPool, err := x509.SystemCertPool()
 
 		if err != nil {
-			err = fmt.Errorf("failed to initialize root CAs: %w", err)
+			log.Printf("[ERROR] : Kafka - failed to initialize root CAs: %v", err)
 		}
 
 		transport.TLS = &tls.Config{

--- a/outputs/kafka.go
+++ b/outputs/kafka.go
@@ -3,6 +3,7 @@ package outputs
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -30,7 +31,14 @@ func NewKafkaClient(config *types.Configuration, stats *types.Statistics, promSt
 	}
 
 	if config.Kafka.TLS {
+		caCertPool, err := x509.SystemCertPool()
+
+		if err != nil {
+			err = fmt.Errorf("failed to initialize root CAs: %w", err)
+		}
+
 		transport.TLS = &tls.Config{
+			RootCAs:    caCertPool,
 			MinVersion: tls.VersionTLS12,
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Tha Kafka TLS output doesn't pick up any root CAs right now, so enabling TLS output should always fail

**Which issue(s) this PR fixes**:

_Maybe_ #547, but not sure, hence not auto-tagging

**Special notes for your reviewer**:

Reviewed by @Issif on Slack

