### PR TITLE
Add global TLS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   keyfile: "/etc/certs/client/client.key" # client key
   cacertfile: "/etc/certs/client/ca.crt" # for server certification
 tlsclient:
-  cacertfile: "/etc/certs/client/ca.crt" # added to the system's tls CA pool
+  cacertfile: "/etc/certs/client/ca.crt" # CA certificate file for server certification on TLS connections, appended to the system CA pool if not empty
 tlsserver:
   deploy: false # if true, TLS server will be deployed instead of HTTP
   certfile: "/etc/certs/server/server.crt" # server certification file

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   certfile: "/etc/certs/client/client.crt" # client certification file
   keyfile: "/etc/certs/client/client.key" # client key
   cacertfile: "/etc/certs/client/ca.crt" # for server certification
+tlsclient:
+  cacertfile: "/etc/certs/client/ca.crt" # added to the system's tls CA pool
 tlsserver:
   deploy: false # if true, TLS server will be deployed instead of HTTP
   certfile: "/etc/certs/server/server.crt" # server certification file
@@ -696,6 +698,7 @@ care of lower/uppercases**) : `yaml: a.b --> envvar: A_B` :
 - **MUTUALTLSCLIENT_CERTFILE**: client certification file for mutual TLS client certification, takes priority over MUTUALTLSFILESPATH if not empty
 - **MUTUALTLSCLIENT_KEYFILE**: client key file for mutual TLS client certification, takes priority over MUTUALTLSFILESPATH if not empty
 - **MUTUALTLSCLIENT_CACERTFILE**: CA certification file for server certification for mutual TLS authentication, takes priority over MUTUALTLSFILESPATH if not empty
+- **TLSCLIENT_CACERTFILE**: CA certificate file for server certification on TLS connections, appended to the system CA pool if not empty
 - **TLSSERVER_DEPLOY**: if _true_ TLS server will be deployed instead of HTTP
 - **TLSSERVER_CERTFILE**: server certification file for TLS Server (default: "/etc/certs/server/server.crt")
 - **TLSSERVER_KEYFILE**: server key file for TLS Server (default: "/etc/certs/server/server.key")

--- a/config.go
+++ b/config.go
@@ -53,6 +53,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("MutualTLSClient.CertFile", "")
 	v.SetDefault("MutualTLSClient.KeyFile", "")
 	v.SetDefault("MutualTLSClient.CaCertFile", "")
+	v.SetDefault("TLSClient.CaCertFile", "")
 
 	v.SetDefault("TLSServer.Deploy", false)
 	v.SetDefault("TLSServer.CertFile", "/etc/certs/server/server.crt")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -14,7 +14,7 @@ mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   keyfile: "/etc/certs/client/client.key" # client key
   cacertfile: "/etc/certs/client/ca.crt" # for server certification
 tlsclient:
-  cacertfile: "/etc/certs/client/ca.crt" # added to the system's tls CA pool
+  cacertfile: "/etc/certs/client/ca.crt" # CA certificate file for server certification on TLS connections, appended to the system CA pool if not empty
 tlsserver:
   deploy: false # if true, TLS server will be deployed instead of HTTP
   certfile: "/etc/certs/server/server.crt" # server certification file

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -13,6 +13,8 @@ mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   certfile: "/etc/certs/client/client.crt" # client certification file
   keyfile: "/etc/certs/client/client.key" # client key
   cacertfile: "/etc/certs/client/ca.crt" # for server certification
+tlsclient:
+  cacertfile: "/etc/certs/client/ca.crt" # added to the system's tls CA pool
 tlsserver:
   deploy: false # if true, TLS server will be deployed instead of HTTP
   certfile: "/etc/certs/server/server.crt" # server certification file

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -194,7 +194,9 @@ func (c *Client) sendRequest(method string, payload interface{}) error {
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if customTransport.TLSClientConfig == nil {
-		customTransport.TLSClientConfig = &tls.Config{}
+		customTransport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 
 	customTransport.TLSClientConfig.MinVersion = tls.VersionTLS12

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -194,10 +194,10 @@ func (c *Client) sendRequest(method string, payload interface{}) error {
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if customTransport.TLSClientConfig == nil {
-		customTransport.TLSClientConfig = &tls.Config{}
+		customTransport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
-
-	customTransport.TLSClientConfig.MinVersion = tls.VersionTLS12
 
 	if customTransport.TLSClientConfig.RootCAs == nil {
 		pool, err := x509.SystemCertPool()

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -194,9 +194,7 @@ func (c *Client) sendRequest(method string, payload interface{}) error {
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 
 	if customTransport.TLSClientConfig == nil {
-		customTransport.TLSClientConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
+		customTransport.TLSClientConfig = &tls.Config{}
 	}
 
 	customTransport.TLSClientConfig.MinVersion = tls.VersionTLS12

--- a/types/types.go
+++ b/types/types.go
@@ -49,6 +49,7 @@ func (f FalcoPayload) Check() bool {
 type Configuration struct {
 	MutualTLSFilesPath string
 	MutualTLSClient    MutualTLSClient
+	TLSClient          TLSClient
 	TLSServer          TLSServer
 	Debug              bool
 	ListenAddress      string
@@ -112,6 +113,11 @@ type Configuration struct {
 type MutualTLSClient struct {
 	CertFile   string
 	KeyFile    string
+	CaCertFile string
+}
+
+// MutualTLSClient represents parameters for global TLS client options
+type TLSClient struct {
 	CaCertFile string
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Following #574, we'd like to be able to specify a custom CA cert on the Kafka output. This PR adds a way to specify custom CAs as a global (i.e. common to all outputs) TLS option.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

For now, this feature just affects outputs that use the outputs.Client.Post() or Put() methods. 