### PR TITLE
Fix interface conversion panic due to incorrect handling of nil output fields in the Dynatrace output

### DIFF
--- a/outputs/dynatrace.go
+++ b/outputs/dynatrace.go
@@ -28,7 +28,7 @@ type dtLogMessage struct {
 	ContainerImageName    string       `json:"container.image.name,omitempty"`
 	K8sNamespaceName      string       `json:"k8s.namespace.name,omitempty"`
 	K8sPodName            string       `json:"k8s.pod.name,omitempty"`
-	K8sPodId              string       `json:"k8s.pod.id,omitempty"`
+	K8sPodUid             string       `json:"k8s.pod.uid,omitempty"`
 	ProcessExecutableName string       `json:"process.executable.name,omitempty"`
 	SpanId                string       `json:"span.id,omitempty"`
 }
@@ -71,14 +71,14 @@ func newDynatracePayload(falcopayload types.FalcoPayload) dtPayload {
 			message.ContainerId = val.(string)
 		case "container.name":
 			message.ContainerName = val.(string)
-		case "container.image.name":
+		case "container.image":
 			message.ContainerImageName = val.(string)
-		case "k8s.namespace.name", "ka.target.namespace":
+		case "k8s.ns.name", "ka.target.namespace":
 			message.K8sNamespaceName = val.(string)
 		case "k8s.pod.name":
 			message.K8sPodName = val.(string)
 		case "k8s.pod.id":
-			message.K8sPodId = val.(string)
+			message.K8sPodUid = val.(string)
 		case "proc.name":
 			message.ProcessExecutableName = val.(string)
 		case "span.id":

--- a/outputs/dynatrace.go
+++ b/outputs/dynatrace.go
@@ -3,6 +3,7 @@ package outputs
 import (
 	"log"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/falcosecurity/falcosidekick/types"
@@ -65,26 +66,32 @@ func newDynatracePayload(falcopayload types.FalcoPayload) dtPayload {
 	}
 
 	// possibly map a few fields to semantic attributes
-	for fcKey, val := range falcopayload.OutputFields {
-		switch fcKey {
-		case "container.id":
-			message.ContainerId = val.(string)
-		case "container.name":
-			message.ContainerName = val.(string)
-		case "container.image":
-			message.ContainerImageName = val.(string)
-		case "k8s.ns.name", "ka.target.namespace":
-			message.K8sNamespaceName = val.(string)
-		case "k8s.pod.name":
-			message.K8sPodName = val.(string)
-		case "k8s.pod.id":
-			message.K8sPodUid = val.(string)
-		case "proc.name":
-			message.ProcessExecutableName = val.(string)
-		case "span.id":
-			message.SpanId = val.(string)
-		default:
-			continue
+	if falcopayload.OutputFields != nil {
+		for fcKey, val := range falcopayload.OutputFields {
+			if val == nil {
+				continue
+			}
+
+			switch fcKey {
+			case "container.id":
+				message.ContainerId = val.(string)
+			case "container.name":
+				message.ContainerName = val.(string)
+			case "container.image":
+				message.ContainerImageName = val.(string)
+			case "k8s.ns.name", "ka.target.namespace":
+				message.K8sNamespaceName = val.(string)
+			case "k8s.pod.name":
+				message.K8sPodName = val.(string)
+			case "k8s.pod.id":
+				message.K8sPodUid = val.(string)
+			case "proc.name":
+				message.ProcessExecutableName = val.(string)
+			case "span.id":
+				message.SpanId = strconv.Itoa(val.(int))
+			default:
+				continue
+			}
 		}
 	}
 

--- a/outputs/dynatrace_test.go
+++ b/outputs/dynatrace_test.go
@@ -1,0 +1,106 @@
+package outputs
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/falcosecurity/falcosidekick/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDynatracePayload(t *testing.T) {
+	expectedOutput := dtPayload{
+		Payload: []dtLogMessage{
+			{
+				Timestamp:     "2001-01-01T01:10:00Z",
+				EventName:     "Test rule",
+				EventProvider: "Falco",
+				Severity:      "Debug",
+				HostName:      "test-host",
+				LogSource:     "syscalls",
+				Content: dtLogContent{
+					Output: "This is a test from falcosidekick",
+					OutputFields: map[string]interface{}{
+						"proc.name": "falcosidekick",
+						"proc.tty":  float64(1234),
+					},
+					Tags: []string{"test", "example"},
+				},
+				ProcessExecutableName: "falcosidekick",
+			},
+		},
+	}
+
+	var f types.FalcoPayload
+	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+
+	output := newDynatracePayload(f)
+	require.Equal(t, output, expectedOutput)
+}
+
+func TestNewDynatracePayloadWithExtraOutputFields(t *testing.T) {
+	const ContainerId = "77d156711504"
+	const ContainerName = "hello-world"
+	const ContainerImageName = "falcosecurity/falco:latest"
+	const K8sNamespaceName = "falco"
+	const K8sPodName = "falco-khx2g"
+	const ProcessExecutableName = "falcosidekick"
+	const SpanId = 1337
+	const MitreTechnique = "T1059"
+	const MitreTactic = "mitre_execution"
+
+	expectedOutput := dtPayload{
+		Payload: []dtLogMessage{
+			{
+				Timestamp:     "2001-01-01T01:10:00Z",
+				EventName:     "Test rule",
+				EventProvider: "Falco",
+				Severity:      "Debug",
+				HostName:      "test-host",
+				LogSource:     "syscalls",
+				Content: dtLogContent{
+					Output: "This is a test from falcosidekick",
+					OutputFields: map[string]interface{}{
+						"container.id":    ContainerId,
+						"container.name":  ContainerName,
+						"container.image": ContainerImageName,
+						"k8s.ns.name":     K8sNamespaceName,
+						"k8s.pod.name":    K8sPodName,
+						"k8s.pod.id":      nil,
+						"proc.name":       ProcessExecutableName,
+						"span.id":         SpanId,
+					},
+					Tags: []string{"test", "example", MitreTechnique, MitreTactic},
+				},
+				ContainerId:           ContainerId,
+				ContainerName:         ContainerName,
+				ContainerImageName:    ContainerImageName,
+				K8sNamespaceName:      K8sNamespaceName,
+				K8sPodName:            K8sPodName,
+				ProcessExecutableName: ProcessExecutableName,
+				SpanId:                strconv.Itoa(SpanId),
+				MitreTactic:           MitreTactic,
+				MitreTechnique:        MitreTechnique,
+			},
+		},
+	}
+
+	var f types.FalcoPayload
+	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+	delete(f.OutputFields, "proc.tty")
+	f.OutputFields["container.id"] = ContainerId
+	f.OutputFields["container.name"] = ContainerName
+	f.OutputFields["container.image"] = ContainerImageName
+	f.OutputFields["k8s.ns.name"] = K8sNamespaceName
+	f.OutputFields["k8s.pod.name"] = K8sPodName
+	f.OutputFields["k8s.pod.id"] = nil
+	f.OutputFields["proc.name"] = ProcessExecutableName
+	f.OutputFields["span.id"] = SpanId
+	f.Tags = append(f.Tags, "T1059")
+	f.Tags = append(f.Tags, "mitre_execution")
+
+	output := newDynatracePayload(f)
+	require.Equal(t, output, expectedOutput)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs
/area tests

**What this PR does / why we need it**:

* Fixes an issue with the Dynatrace output that let falcosidekick panic whenever one of the output fields was nil and thus not convertible to a valid string.
* Also, fixes parsing the INT64 field `span.id` as a string instead of incorrectly casting it directly.
* Adds two test cases for the Dynatrace output.
* Correctly uses the `container.image` and `k8s.ns.name` output fields of Falco.
* Renamed `k8s.pod.id` to `k8s.pod.uid` in the Dynatrace output.
