### PR TITLE
WIP: add outputFieldFormat parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ customfields: # custom fields are added to falco events, if the value starts wit
 templatedfields: # templated fields are added to falco events and metrics, it uses Go template + output_fields values
   # Dkey: '{{ or (index . "k8s.ns.labels.foo") "bar" }}'
 # bracketreplacer: "_" # if not empty, replace the brackets in keys of Output Fields
+outputFieldFormat: "<timestamp>: <priority> <output> <custom_fields> <templated_fields>" # if not empty, allow to change the format of the output field. (default: "<timestamp>: <priority> <output>")
 mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs, will be deprecated in the future (default: "/etc/certs")
 mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   certfile: "/etc/certs/client/client.crt" # client certification file

--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("MutualTLSClient.KeyFile", "")
 	v.SetDefault("MutualTLSClient.CaCertFile", "")
 	v.SetDefault("TLSClient.CaCertFile", "")
+	v.SetDefault("OutputFieldFormat", "")
 
 	v.SetDefault("TLSServer.Deploy", false)
 	v.SetDefault("TLSServer.CertFile", "/etc/certs/server/server.crt")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -8,6 +8,7 @@ customfields: # custom fields are added to falco events and metrics, if the valu
 templatedfields: # templated fields are added to falco events and metrics, it uses Go template + output_fields values
   # Dkey: '{{ or (index . "k8s.ns.labels.foo") "bar" }}'
 # bracketreplacer: "_" # if not empty, the brackets in keys of Output Fields are replaced
+outputFieldFormat: "<timestamp>: <priority> <output> <custom_fields> <templated_fields>" # if not empty, allow to change the format of the output field. (default: "<timestamp>: <priority> <output>")
 mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs, will be deprecated in the future (default: "/etc/certs")
 mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   certfile: "/etc/certs/client/client.crt" # client certification file

--- a/handlers.go
+++ b/handlers.go
@@ -16,11 +16,13 @@ import (
 
 	"github.com/falcosecurity/falcosidekick/types"
 	"github.com/google/uuid"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const testRule string = "Test rule"
 
-// mainHandler is Falco Sidekick main handler (default).
+// mainHandler is Falcosidekick main handler (default).
 func mainHandler(w http.ResponseWriter, r *http.Request) {
 	stats.Requests.Add("total", 1)
 	nullClient.CountMetric("total", 1, []string{})
@@ -89,11 +91,13 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 		return types.FalcoPayload{}, err
 	}
 
+	var customFields string
 	if len(config.Customfields) > 0 {
 		if falcopayload.OutputFields == nil {
 			falcopayload.OutputFields = make(map[string]interface{})
 		}
 		for key, value := range config.Customfields {
+			customFields += key + "=" + value + " "
 			falcopayload.OutputFields[key] = value
 		}
 	}
@@ -120,6 +124,7 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 		}
 	}
 
+	var templatedFields string
 	if len(config.Templatedfields) > 0 {
 		if falcopayload.OutputFields == nil {
 			falcopayload.OutputFields = make(map[string]interface{})
@@ -134,6 +139,7 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 			if err := tmpl.Execute(v, falcopayload.OutputFields); err != nil {
 				log.Printf("[ERROR] : Parsing error for templated field '%v': %v\n", key, err)
 			}
+			templatedFields += key + "=" + v.String() + " "
 			falcopayload.OutputFields[key] = v.String()
 		}
 	}
@@ -180,20 +186,25 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 		}
 	}
 
-	if len(falcopayload.String()) > 4096 {
-		for i, j := range falcopayload.OutputFields {
-			switch j.(type) {
-			case string:
-				if len(j.(string)) > 512 {
-					k := j.(string)[:507] + "[...]"
-					falcopayload.Output = strings.ReplaceAll(falcopayload.Output, j.(string), k)
-					falcopayload.OutputFields[i] = k
-				}
-			}
+	if config.OutputFieldFormat != "" && regOutputFormat.MatchString(falcopayload.Output) {
+		outputElements := strings.Split(falcopayload.Output, " ")
+		if len(outputElements) >= 3 {
+			t := strings.TrimSuffix(outputElements[0], ":")
+			p := cases.Title(language.English).String(falcopayload.Priority.String())
+			o := strings.Join(outputElements[2:], " ")
+			n := config.OutputFieldFormat
+			n = strings.ReplaceAll(n, "<timestamp>", t)
+			n = strings.ReplaceAll(n, "<priority>", p)
+			n = strings.ReplaceAll(n, "<output>", o)
+			n = strings.ReplaceAll(n, "<custom_fields>", strings.TrimSuffix(customFields, " "))
+			n = strings.ReplaceAll(n, "<templated_fields>", strings.TrimSuffix(templatedFields, " "))
+			n = strings.TrimSuffix(n, " ")
+			n = strings.TrimSuffix(n, "( )")
+			n = strings.TrimSuffix(n, "()")
+			n = strings.TrimSuffix(n, " ")
+			falcopayload.Output = n
 		}
 	}
-
-	fmt.Println(falcopayload.String())
 
 	if config.Debug {
 		log.Printf("[DEBUG] : Falco's payload : %v\n", falcopayload.String())

--- a/main.go
+++ b/main.go
@@ -84,8 +84,8 @@ var (
 	promStats                     *types.PromStatistics
 	initClientArgs                *types.InitClientArgs
 
-	regPromLabels *regexp.Regexp
-	shutDownFuncs []func()
+	regPromLabels   *regexp.Regexp
+	regOutputFormat *regexp.Regexp
 )
 
 func init() {
@@ -98,6 +98,7 @@ func init() {
 	}
 
 	regPromLabels, _ = regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+	regOutputFormat, _ = regexp.Compile("(?i)[0-9:]+\\.[0-9]+: (Debug|Informational|Notice|Warning|Error|Critical|Alert|Emergency) .*")
 
 	config = getConfig()
 	stats = getInitStats()

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -92,6 +92,16 @@ const MutualTLSCacertFilename = "/ca.crt"
 const HttpPost = "POST"
 const HttpPut = "PUT"
 
+// HTTP Protocol
+const Http = "http://"
+
+// HTTP Headers
+const Bearer = "Bearer"
+
+// Pahs
+const APIv1Namespaces = "/api/v1/namespaces/"
+const Services = "/services/"
+
 // Headers to add to the client before sending the request
 type Header struct {
 	Key   string

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -30,6 +30,10 @@ const Status200 string = "/200"
 
 var falcoTestInput = `{"output":"This is a test from falcosidekick","priority":"Debug","rule":"Test rule", "time":"2001-01-01T01:10:00Z","source":"syscalls","output_fields": {"proc.name":"falcosidekick", "proc.tty": 1234}, "tags":["test","example"], "hostname":"test-host"}`
 
+const (
+	Path200 = "/200"
+)
+
 func TestNewClient(t *testing.T) {
 	u, _ := url.Parse("http://localhost")
 

--- a/outputs/gcp.go
+++ b/outputs/gcp.go
@@ -17,7 +17,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/googleapis/gax-go/v2"
+	gax "github.com/googleapis/gax-go/v2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 

--- a/outputs/kubeless.go
+++ b/outputs/kubeless.go
@@ -65,7 +65,7 @@ func (c *Client) KubelessCall(falcopayload types.FalcoPayload) {
 
 	if c.Config.Kubeless.Kubeconfig != "" {
 		str, _ := json.Marshal(falcopayload)
-		req := c.KubernetesClient.CoreV1().RESTClient().Post().AbsPath("/api/v1/namespaces/" + c.Config.Kubeless.Namespace + "/services/" + c.Config.Kubeless.Function + ":" + strconv.Itoa(c.Config.Kubeless.Port) + "/proxy/").Body(str)
+		req := c.KubernetesClient.CoreV1().RESTClient().Post().AbsPath(APIv1Namespaces + c.Config.Kubeless.Namespace + Services + c.Config.Kubeless.Function + ":" + strconv.Itoa(c.Config.Kubeless.Port) + "/proxy/").Body(str)
 		req.SetHeader(KubelessEventIDKey, uuid.New().String())
 		req.SetHeader(ContentTypeHeaderKey, KubelessContentType)
 		req.SetHeader(UserAgentHeaderKey, UserAgentHeaderValue)

--- a/outputs/openfaas.go
+++ b/outputs/openfaas.go
@@ -57,7 +57,7 @@ func (c *Client) OpenfaasCall(falcopayload types.FalcoPayload) {
 
 	if c.Config.Openfaas.Kubeconfig != "" {
 		str, _ := json.Marshal(falcopayload)
-		req := c.KubernetesClient.CoreV1().RESTClient().Post().AbsPath("/api/v1/namespaces/" + c.Config.Openfaas.GatewayNamespace + "/services/" + c.Config.Openfaas.GatewayService + ":" + strconv.Itoa(c.Config.Openfaas.GatewayPort) + "/proxy" + "/function/" + c.Config.Openfaas.FunctionName + "." + c.Config.Openfaas.FunctionNamespace).Body(str)
+		req := c.KubernetesClient.CoreV1().RESTClient().Post().AbsPath(APIv1Namespaces + c.Config.Openfaas.GatewayNamespace + Services + c.Config.Openfaas.GatewayService + ":" + strconv.Itoa(c.Config.Openfaas.GatewayPort) + "/proxy" + "/function/" + c.Config.Openfaas.FunctionName + "." + c.Config.Openfaas.FunctionNamespace).Body(str)
 		req.SetHeader("event-id", uuid.New().String())
 		req.SetHeader("Content-Type", "application/json")
 		req.SetHeader("User-Agent", "Falcosidekick")

--- a/outputs/pagerduty.go
+++ b/outputs/pagerduty.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PagerDuty/go-pagerduty"
+	pagerduty "github.com/PagerDuty/go-pagerduty"
 
 	"github.com/falcosecurity/falcosidekick/types"
 )

--- a/outputs/spyderbat.go
+++ b/outputs/spyderbat.go
@@ -230,7 +230,7 @@ func (c *Client) SpyderbatPost(falcopayload types.FalcoPayload) {
 
 	c.httpClientLock.Lock()
 	defer c.httpClientLock.Unlock()
-	c.AddHeader("Authorization", "Bearer "+c.Config.Spyderbat.APIKey)
+	c.AddHeader("Authorization", Bearer+" "+c.Config.Spyderbat.APIKey)
 	c.AddHeader("Content-Encoding", "gzip")
 
 	payload, err := newSpyderbatPayload(falcopayload)

--- a/types/types.go
+++ b/types/types.go
@@ -58,6 +58,7 @@ type Configuration struct {
 	ListenAddress      string
 	ListenPort         int
 	BracketReplacer    string
+	OutputFieldFormat  string
 	Customfields       map[string]string
 	Templatedfields    map[string]string
 	Prometheus         prometheusOutputConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area config

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces a new parameter `outputFieldFormat`:

* `outputFieldFormat: "<timestamp>: <priority> <output> <custom_fields> <templated_fields>"`
```
17:50:29.343280037: Warning NodePort Service Created (user=%ka.user.name service=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ports=%ka.req.service.ports) bkey=BValue ckey=CValue dkey=bar
```
* `outputFieldFormat: "<priority> <output> <custom_fields>"`
```
Warning NodePort Service Created (user=%ka.user.name service=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ports=%ka.req.service.ports) bkey=BValue ckey=CValue
```
* `outputFieldFormat: "<output> "`
```
NodePort Service Created (user=%ka.user.name service=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ports=%ka.req.service.ports)
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

#711 

**Special notes for your reviewer**:


