### PR TITLE
Make S3 output compatible with non-AWS S3 API-compliant endpoints

### DIFF
--- a/config.go
+++ b/config.go
@@ -215,6 +215,8 @@ func getConfig() *types.Configuration {
 	v.SetDefault("AWS.S3.Bucket", "")
 	v.SetDefault("AWS.S3.Prefix", "falco")
 	v.SetDefault("AWS.S3.MinimumPriority", "")
+	v.SetDefault("AWS.S3.Endpoint", "")
+	v.SetDefault("AWS.S3.ObjectCannedACL", "bucket-owner-full-control")
 
 	v.SetDefault("AWS.SecurityLake.Bucket", "")
 	v.SetDefault("AWS.SecurityLake.Region", "")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -170,8 +170,10 @@ aws:
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
   s3:
     # bucket: "falcosidekick" # AWS S3, bucket name
-    # prefix : "" # name of prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json
+    # prefix: "" # name of prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
+    # endpoint: "" # endpoint URL that overrides the default generated endpoint, use this for S3 compatible APIs
+    # objectcannedacl: "bucket-owner-full-control" # Canned ACL (x-amz-acl) to use when creating the object
   securitylake.:
     # bucket: "" # Bucket for AWS SecurityLake data, if not empty, AWS SecurityLake output is enabled
     # region: "" # Bucket Region  (mandatory)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,3 +58,15 @@ services:
     ports:
       - "9093:9093"
     profiles: [alertmanager]
+
+  minio:
+    image: quay.io/minio/minio
+    environment:
+      - MINIO_ROOT_USER=root
+      - MINIO_ROOT_PASSWORD=super-secret
+      - MINIO_DOMAIN=minio.localhost
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    profiles: [minio]

--- a/docs/outputs/aws_s3.md
+++ b/docs/outputs/aws_s3.md
@@ -14,17 +14,19 @@
 
 ## Configuration
 
-| Setting                  | Env var                  | Default value    | Description                                                                                                                         |
-| ------------------------ | ------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `aws.accesskeyid`        | `AWS_ACCESSKEYID`        |                  | AWS access key (optional if you use EC2 Instance Profile)                                                                           |
-| `aws.secretaccesskey`    | `AWS_SECRETACCESSKEY`    |                  | AWS secret access key (optional if you use EC2 Instance Profile)                                                                    |
-| `aws.region`             | `AWS_REGION`             |                  | AWS region (by default, the metadata are used to get it)                                                                            |
-| `aws.rolearn`            | `AWS_ROLEARN`            |                  | AWS role to assume (optional if you use EC2 Instance Profile)                                                                       |
-| `aws.externalid`         | `AWS_EXTERNALID`         |                  | External id for the role to assume (optional if you use EC2 Instance Profile)                                                       |
-| `aws.checkidentity`      | `AWS_checkidentity`      | `true`           | Check the identity credentials, set to false for locale developments                                                                |
-| `aws.s3.bucket`          | `AWS_S3_BUCKET`          |                  | AWS S3 bucket name, if not empty, AWS S3 output is **enabled**                                                                      |
-| `aws.s3.prefix`          | `AWS_S3_PREFIX`          |                  | Prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json                                   |
-| `aws.s3.minimumpriority` | `AWS_S3_MINIMUMPRIORITY` | `""` (= `debug`) | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
+| Setting                  | Env var                  | Default value               | Description                                                                                                                         |
+|--------------------------|--------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `aws.accesskeyid`        | `AWS_ACCESSKEYID`        |                             | AWS access key (optional if you use EC2 Instance Profile)                                                                           |
+| `aws.secretaccesskey`    | `AWS_SECRETACCESSKEY`    |                             | AWS secret access key (optional if you use EC2 Instance Profile)                                                                    |
+| `aws.region`             | `AWS_REGION`             |                             | AWS region (by default, the metadata are used to get it)                                                                            |
+| `aws.rolearn`            | `AWS_ROLEARN`            |                             | AWS role to assume (optional if you use EC2 Instance Profile)                                                                       |
+| `aws.externalid`         | `AWS_EXTERNALID`         |                             | External id for the role to assume (optional if you use EC2 Instance Profile)                                                       |
+| `aws.checkidentity`      | `AWS_checkidentity`      | `true`                      | Check the identity credentials, set to false for locale developments                                                                |
+| `aws.s3.bucket`          | `AWS_S3_BUCKET`          |                             | AWS S3 bucket name, if not empty, AWS S3 output is **enabled**                                                                      |
+| `aws.s3.prefix`          | `AWS_S3_PREFIX`          |                             | Prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json                                   |
+| `aws.s3.minimumpriority` | `AWS_S3_MINIMUMPRIORITY` | `""` (= `debug`)            | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
+| `aws.s3.endpoint`        | `AWS_S3_ENDPOINT`        |                             | Endpoint URL that overrides the default generated endpoint, use this for S3 compatible APIs                                         |
+| `aws.s3.objectcannedacl` | `AWS_S3_OBJECTCANNEDACL` | `bucket-owner-full-control` | Canned ACL (`x-amz-acl`) to use when creating the object                                                                            |
 
 > **Note**
 The Env var values override the settings from yaml file.
@@ -43,6 +45,8 @@ aws:
     bucket: "falcosidekick" # AWS S3, bucket name
     prefix : "" # Prefix, keys will have format: s3://<bucket>/<prefix>/YYYY-MM-DD/YYYY-MM-DDTHH:mm:ss.s+01:00.json
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
+    # endpoint: "" # endpoint URL that overrides the default generated endpoint, use this for S3 compatible APIs
+    # objectcannedacl: "bucket-owner-full-control" # Canned ACL (x-amz-acl) to use when creating the object
 ```
 
 ## Additional info

--- a/outputs/aws.go
+++ b/outputs/aws.go
@@ -212,11 +212,15 @@ func (c *Client) UploadS3(falcopayload types.FalcoPayload) {
 	}
 
 	key := fmt.Sprintf("%s/%s/%s.json", prefix, t.Format("2006-01-02"), t.Format(time.RFC3339Nano))
-	resp, err := s3.New(c.AWSSession).PutObject(&s3.PutObjectInput{
+	awsConfig := aws.NewConfig()
+	if c.Config.AWS.S3.Endpoint != "" {
+		awsConfig = awsConfig.WithEndpoint(c.Config.AWS.S3.Endpoint)
+	}
+	resp, err := s3.New(c.AWSSession, awsConfig).PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(c.Config.AWS.S3.Bucket),
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(f),
-		ACL:    aws.String(s3.ObjectCannedACLBucketOwnerFullControl),
+		ACL:    aws.String(c.Config.AWS.S3.ObjectCannedACL),
 	})
 	if err != nil {
 		go c.CountMetric("outputs", 1, []string{"output:awss3", "status:error"})

--- a/types/types.go
+++ b/types/types.go
@@ -403,6 +403,8 @@ type awsS3Config struct {
 	Prefix          string
 	Bucket          string
 	MinimumPriority string
+	Endpoint        string
+	ObjectCannedACL string
 }
 
 type awsKinesisConfig struct {


### PR DESCRIPTION
Changes: 

- add AWS.S3.Endpoint configuration option
- make canned ACL configurable
- add MinIO to `docker-compose.yaml` for local testing

/kind feature
/area outputs

I tested this change against [IBM Cloud COS](https://www.ibm.com/products/cloud-object-storage) and a local [MinIO](https://min.io/) instance.

Example `config.yaml` for the local MinIO:

```yaml
aws:
  region: minio
  checkidentity: false
  accesskeyid: xxx
  secretaccesskey: xxx
  s3:
    bucket: falco-test
    endpoint: http://minio.localhost:9000
    objectcannedacl: ""
```