### PR TITLE
Added 'Install' section to systemd example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ docker run -d -p 2801:2801 -e SLACK_WEBHOOKURL=XXXX -e DATADOG_APIKEY=XXXX falco
   Type=simple
   Restart=always
   RestartSec=1
-  ExecStart=/usr/local/bin/falcosidekick -c /etc/falcosidekick/config.yaml 
+  ExecStart=/usr/local/bin/falcosidekick -c /etc/falcosidekick/config.yaml
+
+  [Install]
+  WantedBy=default.target
   ```
 
 * Reload `systemd` and start `Falcosidekick`:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

/area config

**What this PR does / why we need it**:

This PR adds the `[Install]` section in the Systemd Installation example in README.
This is required for enabling and disabling services, as per [RedHat Documentation](https://access.redhat.com/documentation/enus/red_hat_enterprise_linux/9/html-single/using_systemd_unit_files_to_customize_and_optimize_your_system/index#con_unit-file-structure_assembly_working-with-systemd-unit-files).

When following the systemd installation example, `sudo systemctl enable falcosidekick` currently fails with the following error:
```
The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
Alias= settings in the [Install] section, and DefaultInstance= for template
units). This means they are not meant to be enabled using systemctl.

Possible reasons for having this kind of units are:
• A unit may be statically enabled by being symlinked from another unit's
  .wants/ or .requires/ directory.
• A unit's purpose may be to act as a helper for some other unit which has
  a requirement dependency on it.
• A unit may be started when needed via activation (socket, path, timer,
  D-Bus, udev, scripted systemctl call, ...).
• In case of template units, the unit is meant to be enabled with some
  instance name specified.
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


