### PR TITLE
feat(alertmanager): fix labels for alertmanager

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -168,5 +168,6 @@ func (c *Client) AlertmanagerPost(falcopayload types.FalcoPayload) {
 
 func alertmanagerSafeLabel(label string) string {
 	replace := replacer.Replace(label)
-	return reg.ReplaceAllString(replace, "_")
+	underscored := reg.ReplaceAllString(replace, "_")
+	return strings.ReplaceAll(underscored, "__", "_")
 }

--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -48,8 +48,7 @@ var defaultSeverityMap = map[types.PriorityType]string{
 
 // labels should match [a-zA-Z_][a-zA-Z0-9_]*
 var (
-	reg      = regexp.MustCompile("[^a-zA-Z0-9_]")
-	replacer = strings.NewReplacer("]", "", ")", "", "}", "")
+	reg = regexp.MustCompile("[^a-zA-Z0-9_]")
 )
 
 func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Configuration) []alertmanagerPayload {
@@ -167,7 +166,12 @@ func (c *Client) AlertmanagerPost(falcopayload types.FalcoPayload) {
 }
 
 func alertmanagerSafeLabel(label string) string {
-	replace := replacer.Replace(label)
-	underscored := reg.ReplaceAllString(replace, "_")
-	return strings.ReplaceAll(underscored, "__", "_")
+	// replace all unsafe characters with _
+	replaced := reg.ReplaceAllString(label, "_")
+	// remove double __
+	replaced = strings.ReplaceAll(replaced, "__", "_")
+	// remove trailing _
+	replaced = strings.TrimRight(replaced, "_")
+	// remove leading _
+	return strings.TrimLeft(replaced, "_")
 }

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -122,6 +122,14 @@ func Test_alertmanagerSafeLabel(t *testing.T) {
 			want:  "host_name",
 		},
 		{
+			label: "{host}[name]",
+			want:  "host_name",
+		},
+		{
+			label: "host[name]other",
+			want:  "host_name_other",
+		},
+		{
 			label: "host(name)",
 			want:  "host_name",
 		},

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -127,7 +127,7 @@ func Test_alertmanagerSafeLabel(t *testing.T) {
 		},
 		{
 			label: "json.value[/user/extra/sessionName]",
-			want:  "json_value__user_extra_sessionName",
+			want:  "json_value_user_extra_sessionName",
 		},
 	}
 	for _, tt := range tests {

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -75,3 +75,27 @@ func TestNewAlertmanagerPayloadDropEvent(t *testing.T) {
 
 	require.Equal(t, o1, o2)
 }
+
+func TestNewAlertmanagerPayloadBadLabels(t *testing.T) {
+	input := `{"hostname":"host","output":"Falco internal: syscall event drop. 815508 system calls dropped in last second.","output_fields":{"ebpf/enabled":"1","n drops/buffer?clone{fork]enter":"0","n_drops_buffer_clone_fork_exit":"0"},"priority":"Debug","rule":"Falco internal: syscall event drop","time":"2023-03-03T03:03:03.000000003Z"}`
+	expectedOutput := `[{"labels":{"ebpf_enabled":"1","eventsource":"","hostname":"host","n_drops_buffer_clone_fork_enter":"0","n_drops_buffer_clone_fork_exit":"0","priority":"Warning","rule":"Falco internal: syscall event drop","severity":"warning","source":"falco"},"annotations":{"description":"Falco internal: syscall event drop. 815508 system calls dropped in last second.","info":"Falco internal: syscall event drop. 815508 system calls dropped in last second.","summary":"Falco internal: syscall event drop"},"endsAt":"0001-01-01T00:00:00Z"}]`
+	var f types.FalcoPayload
+	d := json.NewDecoder(strings.NewReader(input))
+	d.UseNumber()
+	err := d.Decode(&f) //have to decode it the way newFalcoPayload does
+	require.Nil(t, err)
+
+	config := &types.Configuration{
+		Alertmanager: types.AlertmanagerOutputConfig{DropEventDefaultPriority: Critical},
+	}
+	json.Unmarshal([]byte(defaultThresholds), &config.Alertmanager.DropEventThresholdsList)
+
+	s, err := json.Marshal(newAlertmanagerPayload(f, config))
+	require.Nil(t, err)
+
+	var o1, o2 []alertmanagerPayload
+	require.Nil(t, json.Unmarshal([]byte(expectedOutput), &o1))
+	require.Nil(t, json.Unmarshal(s, &o2))
+
+	require.Equal(t, o1, o2)
+}

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -99,3 +99,42 @@ func TestNewAlertmanagerPayloadBadLabels(t *testing.T) {
 
 	require.Equal(t, o1, o2)
 }
+
+func Test_alertmanagerSafeLabel(t *testing.T) {
+	tests := []struct {
+		label string
+		want  string
+	}{
+		{
+			label: "host",
+			want:  "host",
+		},
+		{
+			label: "host_name",
+			want:  "host_name",
+		},
+		{
+			label: "host{name}",
+			want:  "host_name",
+		},
+		{
+			label: "host[name]",
+			want:  "host_name",
+		},
+		{
+			label: "host(name)",
+			want:  "host_name",
+		},
+		{
+			label: "json.value[/user/extra/sessionName]",
+			want:  "json_value__user_extra_sessionName",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			if got := alertmanagerSafeLabel(tt.label); got != tt.want {
+				t.Errorf("alertmanagerSafeLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The labels used by alertmanager need to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`. 

When adding a custom rule to get the AWS session name the label passed in is `json.value[/user/extra/sessionName]` which is currently passes out to alertmanager as `json_value_/user/extra/sessionName` which doesn't work in Alertmanager as the `/` are invalid.

**Special notes for your reviewer**:


