### PR TITLE
truncate output fiels with a length > 512 chars

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -195,9 +195,23 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 		}
 	}
 
+	if len(falcopayload.String()) > 4096 {
+		for i, j := range falcopayload.OutputFields {
+			switch j.(type) {
+			case string:
+				if len(j.(string)) > 512 {
+					k := j.(string)[:507] + "[...]"
+					falcopayload.Output = strings.ReplaceAll(falcopayload.Output, j.(string), k)
+					falcopayload.OutputFields[i] = k
+				}
+			}
+		}
+	}
+
+	fmt.Println(falcopayload.String())
+
 	if config.Debug {
-		body, _ := json.Marshal(falcopayload)
-		log.Printf("[DEBUG] : Falco's payload : %v\n", string(body))
+		log.Printf("[DEBUG] : Falco's payload : %v\n", falcopayload.String())
 	}
 
 	return falcopayload, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

> /area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Multiple outputs fail when the length of the payload is > 4906 characters. This PR introduces a truncate of the outputs fields to max 512 characters when the global length of the payload is > 4096.

**Which issue(s) this PR fixes**:

#842 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


