### PR TITLE
add outputFieldFormat parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
 
 .PHONY: goreleaser-snapshot
 goreleaser-snapshot: ## Release snapshot using goreleaser
-	LDFLAGS="$(LDFLAGS)" goreleaser --snapshot --skip-sign --clean
+	LDFLAGS="$(LDFLAGS)" goreleaser --snapshot --skip=sign --clean
 
 ## --------------------------------------
 ## Tooling Binaries

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ customfields: # custom fields are added to falco events, if the value starts wit
 templatedfields: # templated fields are added to falco events and metrics, it uses Go template + output_fields values
   # Dkey: '{{ or (index . "k8s.ns.labels.foo") "bar" }}'
 # bracketreplacer: "_" # if not empty, replace the brackets in keys of Output Fields
+outputFieldFormat: "<timestamp>: <priority> <output> <custom_fields> <templated_fields>" # if not empty, allow to change the format of the output field. (default: "<timestamp>: <priority> <output>")
 mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs, will be deprecated in the future (default: "/etc/certs")
 mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   certfile: "/etc/certs/client/client.crt" # client certification file

--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("MutualTLSClient.KeyFile", "")
 	v.SetDefault("MutualTLSClient.CaCertFile", "")
 	v.SetDefault("TLSClient.CaCertFile", "")
+	v.SetDefault("OutputFieldFormat", "")
 
 	v.SetDefault("TLSServer.Deploy", false)
 	v.SetDefault("TLSServer.CertFile", "/etc/certs/server/server.crt")

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -8,6 +8,7 @@ customfields: # custom fields are added to falco events and metrics, if the valu
 templatedfields: # templated fields are added to falco events and metrics, it uses Go template + output_fields values
   # Dkey: '{{ or (index . "k8s.ns.labels.foo") "bar" }}'
 # bracketreplacer: "_" # if not empty, the brackets in keys of Output Fields are replaced
+outputFieldFormat: "<timestamp>: <priority> <output> <custom_fields> <templated_fields>" # if not empty, allow to change the format of the output field. (default: "<timestamp>: <priority> <output>")
 mutualtlsfilespath: "/etc/certs" # folder which will used to store client.crt, client.key and ca.crt files for mutual tls for outputs, will be deprecated in the future (default: "/etc/certs")
 mutualtlsclient: # takes priority over mutualtlsfilespath if not emtpy
   certfile: "/etc/certs/client/client.crt" # client certification file

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
 	golang.org/x/oauth2 v0.20.0
+	golang.org/x/text v0.15.0
 	google.golang.org/api v0.181.0
 	google.golang.org/genproto v0.0.0-20240415180920-8c6c420018be
 	k8s.io/api v0.30.1
@@ -138,7 +139,6 @@ require (
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
-	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240506185236-b8a5c65736ae // indirect

--- a/main.go
+++ b/main.go
@@ -84,8 +84,9 @@ var (
 	promStats                     *types.PromStatistics
 	initClientArgs                *types.InitClientArgs
 
-	regPromLabels *regexp.Regexp
-	shutDownFuncs []func()
+	regPromLabels   *regexp.Regexp
+	regOutputFormat *regexp.Regexp
+	shutDownFuncs   []func()
 )
 
 func init() {
@@ -98,6 +99,7 @@ func init() {
 	}
 
 	regPromLabels, _ = regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+	regOutputFormat, _ = regexp.Compile(`(?i)[0-9:]+\.[0-9]+: (Debug|Informational|Notice|Warning|Error|Critical|Alert|Emergency) .*`)
 
 	config = getConfig()
 	stats = getInitStats()

--- a/types/types.go
+++ b/types/types.go
@@ -58,6 +58,7 @@ type Configuration struct {
 	ListenAddress      string
 	ListenPort         int
 	BracketReplacer    string
+	OutputFieldFormat  string
 	Customfields       map[string]string
 	Templatedfields    map[string]string
 	Prometheus         prometheusOutputConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area config

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces a new parameter `outputFieldFormat`:

* `outputFieldFormat: "<timestamp>: <priority> <output> <custom_fields> <templated_fields>"`
```
17:50:29.343280037: Warning NodePort Service Created (user=%ka.user.name service=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ports=%ka.req.service.ports) bkey=BValue ckey=CValue dkey=bar
```
* `outputFieldFormat: "<priority> <output> <custom_fields>"`
```
Warning NodePort Service Created (user=%ka.user.name service=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ports=%ka.req.service.ports) bkey=BValue ckey=CValue
```
* `outputFieldFormat: "<output> "`
```
NodePort Service Created (user=%ka.user.name service=%ka.target.name resource=%ka.target.resource ns=%ka.target.namespace ports=%ka.req.service.ports)
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

#711 

**Special notes for your reviewer**:


