### PR TITLE
Reuse http client

### DIFF
--- a/outputs/client.go
+++ b/outputs/client.go
@@ -233,6 +233,7 @@ func (c *Client) sendRequest(method string, payload interface{}) error {
 	}
 	if err != nil {
 		log.Printf("[ERROR] : %v - %v\n", c.OutputType, err.Error())
+		return err
 	}
 
 	req.Header.Add(ContentTypeHeaderKey, c.ContentType)

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -321,7 +321,7 @@ func (c *Client) httpClient() *http.Client {
 }
 
 // configureTransport configure http transport
-// This preserves the previous behavour where it only logged errors, but returned misconfigured transport in case of errors
+// This preserves the previous behavior where it only logged errors, but returned misconfigured transport in case of errors
 func (c *Client) configureTransport() (*http.Transport, error) {
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

This PR reuses http.Client instance for the outputs, were it was previously created per each request.
The http.Client reuse is recommended:
https://cs.opensource.google/go/go/+/refs/tags/go1.22.6:src/net/http/client.go;l=34

We are seeing 3-4x increase of throughput for Elasticsearch output in out tests.

I tried to keep the approach to the http client and the transport creation the same as before, namely logging and continuing on error, extracted some code into the function. 