### PR TITLE
Improve http output handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,397 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
+// Max concurrent requests at a time per output, unlimited if set to 0
+// Setting it to 1 by default, because the previously
+// many outputs were synchronized on headers locks, in all or some cases
+// and that was limiting the the number of requests to 1 at a time.
+const defaultMaxConcurrentHttpRequests = 1
+
+// Common http outputs defaults
+var commonHttpOutputDefaults = map[string]any{
+	"MutualTLS": false,
+	"CheckCert": true,
+	// Max concurrent requests at a time per http-based output
+	"MaxConcurrentRequests": defaultMaxConcurrentHttpRequests,
+}
+
+// Http based outputs that share the common http defaults above
+var httpOutputDefaults = map[string]map[string]any{
+	"Slack": {
+		"WebhookURL":      "",
+		"Footer":          "https://github.com/falcosecurity/falcosidekick",
+		"Username":        "Falcosidekick",
+		"Channel":         "",
+		"Icon":            "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png",
+		"OutputFormat":    "all",
+		"MessageFormat":   "",
+		"MinimumPriority": "",
+	},
+	"Rocketchat": {
+		"WebhookURL":      "",
+		"Footer":          "https://github.com/falcosecurity/falcosidekick",
+		"Username":        "Falcosidekick",
+		"Icon":            "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png",
+		"OutputFormat":    "all",
+		"MessageFormat":   "",
+		"MinimumPriority": "",
+	},
+	"Mattermost": {
+		"WebhookURL":      "",
+		"Footer":          "https://github.com/falcosecurity/falcosidekick",
+		"Username":        "Falcosidekick",
+		"Icon":            "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png",
+		"OutputFormat":    "all",
+		"MessageFormat":   "",
+		"MinimumPriority": "",
+	},
+	"Teams": {
+		"WebhookURL":      "",
+		"ActivityImage":   "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png",
+		"OutputFormat":    "all",
+		"MinimumPriority": "",
+	},
+	"Datadog": {
+		"APIKey":          "",
+		"Host":            "https://api.datadoghq.com",
+		"MinimumPriority": "",
+	},
+	"Discord": {
+		"WebhookURL":      "",
+		"MinimumPriority": "",
+		"Icon":            "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png",
+	},
+	"Alertmanager": {
+		"HostPort":                 "",
+		"MinimumPriority":          "",
+		"Endpoint":                 "/api/v1/alerts",
+		"ExpiresAfter":             0,
+		"DropEventDefaultPriority": "critical",
+		"DropEventThresholds":      "10000:critical: 1000:critical: 100:critical: 10:warning: 1:warning",
+	},
+	"Elasticsearch": {
+		"HostPort":            "",
+		"Index":               "falco",
+		"Type":                "_doc",
+		"MinimumPriority":     "",
+		"Suffix":              "daily",
+		"Username":            "",
+		"Password":            "",
+		"FlattenFields":       false,
+		"CreateIndexTemplate": false,
+		"NumberOfShards":      3,
+		"NumberOfReplicas":    3,
+	},
+	"Quickwit": {
+		"HostPort":        "",
+		"Index":           "falco",
+		"ApiEndpoint":     "api/v1",
+		"Version":         "0.7",
+		"AutoCreateIndex": false,
+		"MinimumPriority": "",
+	},
+	"Influxdb": {
+		"HostPort":        "",
+		"Database":        "falco",
+		"Organization":    "",
+		"Bucket":          "falco",
+		"Precision":       "ns",
+		"User":            "",
+		"Password":        "",
+		"Token":           "",
+		"MinimumPriority": "",
+	},
+	"Loki": {
+		"HostPort":        "",
+		"User":            "",
+		"APIKey":          "",
+		"MinimumPriority": "",
+		"Tenant":          "",
+		"Endpoint":        "/loki/api/v1/push",
+		"ExtraLabels":     "",
+	},
+	"SumoLogic": {
+		"MinimumPriority": "",
+		"ReceiverURL":     "",
+		"SourceCategory":  "",
+		"SourceHost":      "",
+		"Name":            "",
+	},
+	"STAN": {
+		"HostPort":  "",
+		"ClusterID": "",
+		"ClientID":  "",
+	},
+	"NATS": {
+		"HostPort":  "",
+		"ClusterID": "",
+		"ClientID":  "",
+	},
+	"Opsgenie": {
+		"Region":          "us",
+		"APIKey":          "",
+		"MinimumPriority": "",
+	},
+	"Webhook": {
+		"Address":         "",
+		"Method":          "POST",
+		"MinimumPriority": "",
+	},
+	"CloudEvents": {
+		"Address":         "",
+		"MinimumPriority": "",
+	},
+	"Googlechat": {
+		"WebhookURL":      "",
+		"OutputFormat":    "all",
+		"MessageFormat":   "",
+		"MinimumPriority": "",
+	},
+	"Cliq": {
+		"WebhookURL":      "",
+		"Icon":            "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png",
+		"OutputFormat":    "all",
+		"UseEmoji":        false,
+		"MessageFormat":   "",
+		"MinimumPriority": "",
+	},
+	"KafkaRest": {
+		"Address":         "",
+		"Version":         2,
+		"MinimumPriority": "",
+	},
+	"Pagerduty": {
+		"RoutingKey":      "",
+		"Region":          "us",
+		"MinimumPriority": "",
+	},
+	"Kubeless": {
+		"Namespace":       "",
+		"Function":        "",
+		"Port":            8080,
+		"Kubeconfig":      "",
+		"MinimumPriority": "",
+	},
+	"Openfaas": {
+		"GatewayNamespace":  "openfaas",
+		"GatewayService":    "gateway",
+		"FunctionName":      "",
+		"FunctionNamespace": "openfaas-fn",
+		"GatewayPort":       8080,
+		"Kubeconfig":        "",
+		"MinimumPriority":   "",
+	},
+	"Fission": {
+		"RouterNamespace":   "fission",
+		"RouterService":     "router",
+		"RouterPort":        80,
+		"FunctionNamespace": "fission-function",
+		"Function":          "",
+		"Kubeconfig":        "",
+		"MinimumPriority":   "",
+		"MutualTLS":         false,
+		"CheckCert":         true,
+	},
+	"Webui": {
+		"URL": "",
+	},
+	"Grafana": {
+		"HostPort":        "",
+		"DashboardID":     0,
+		"PanelID":         0,
+		"APIKey":          "",
+		"AllFieldsAsTags": false,
+		"MinimumPriority": "",
+	},
+	"GrafanaOnCall": {
+		"WebhookURL":      "",
+		"MinimumPriority": "",
+	},
+	"Redis": {
+		"Address":         "",
+		"Password":        "",
+		"Database":        0,
+		"StorageType":     "list",
+		"Key":             "falco",
+		"MinimumPriority": "",
+	},
+	"OpenObserve": {
+		"HostPort":         "",
+		"OrganizationName": "default",
+		"StreamName":       "falco",
+		"MinimumPriority":  "",
+		"Username":         "",
+		"Password":         "",
+	},
+}
+
+// Other output defaults that do not need commonHttpOutputDefaults
+var outputDefaults = map[string]map[string]any{
+	"SMTP": {
+		"HostPort":        "",
+		"Tls":             true,
+		"From":            "",
+		"To":              "",
+		"OutputFormat":    "html",
+		"MinimumPriority": "",
+		"AuthMechanism":   "plain",
+		"User":            "",
+		"Password":        "",
+		"Token":           "",
+		"Identity":        "",
+		"Trace":           "",
+	},
+	"Statsd": {
+		"Forwarder": "",
+		"Namespace": "falcosidekick.",
+	},
+	"Dogstatsd": {
+		"Forwarder": "",
+		"Namespace": "falcosidekick.",
+		"Tags":      []string{},
+	},
+	"NodeRed": {
+		"Address":         "",
+		"User":            "",
+		"Password":        "",
+		"MinimumPriority": "",
+		"CheckCert":       true,
+	},
+	"Kafka": {
+		"HostPort":        "",
+		"Topic":           "",
+		"MinimumPriority": "",
+		"SASL":            "",
+		"TLS":             false,
+		"Username":        "",
+		"Password":        "",
+		"Balancer":        "round_robin",
+		"ClientID":        "",
+		"Compression":     "NONE",
+		"Async":           false,
+		"RequiredACKs":    "NONE",
+		"TopicCreation":   false,
+	},
+	"PolicyReport": {
+		"Enabled":         false,
+		"Kubeconfig":      "",
+		"MinimumPriority": "",
+		"MaxEvents":       1000,
+		"FalcoNamespace":  "",
+		"PruneByPriority": false,
+	},
+	"Rabbitmq": {
+		"URL":             "",
+		"Queue":           "",
+		"MinimumPriority": "",
+	},
+	"Wavefront": {
+		"EndpointType":        "",
+		"EndpointHost":        "",
+		"EndpointToken":       "",
+		"MetricName":          "falco.alert",
+		"EndpointMetricPort":  2878,
+		"MinimumPriority":     "",
+		"FlushIntervalSecods": 1,
+		"BatchSize":           10000,
+	},
+	"Syslog": {
+		"Host":            "",
+		"Port":            "",
+		"Protocol":        "",
+		"Format":          "json",
+		"MinimumPriority": "",
+	},
+	"MQTT": {
+		"Broker":          "",
+		"Topic":           "falco/events",
+		"QOS":             0,
+		"Retained":        false,
+		"User":            "",
+		"Password":        "",
+		"CheckCert":       true,
+		"MinimumPriority": "",
+	},
+	"Zincsearch": {
+		"HostPort":        "",
+		"Index":           "falco",
+		"Username":        "",
+		"Password":        "",
+		"CheckCert":       true,
+		"MinimumPriority": "",
+	},
+	"Gotify": {
+		"HostPort":        "",
+		"Token":           "",
+		"Format":          "markdown",
+		"CheckCert":       true,
+		"MinimumPriority": "",
+	},
+	"Tekton": {
+		"EventListener":   "",
+		"MinimumPriority": "",
+		"CheckCert":       true,
+	},
+	"Spyderbat": {
+		"OrgUID":            "",
+		"APIKey":            "",
+		"APIUrl":            "https://api.spyderbat.com",
+		"Source":            "falcosidekick",
+		"SourceDescription": "",
+		"MinimumPriority":   "",
+	},
+	"TimescaleDB": {
+		"Host":            "",
+		"Port":            "5432",
+		"User":            "postgres",
+		"Password":        "postgres",
+		"Database":        "falcosidekick",
+		"HypertableName":  "falcosidekick_events",
+		"MinimumPriority": "",
+	},
+	"N8n": {
+		"Address":         "",
+		"User":            "",
+		"Password":        "",
+		"HeaderAuthName":  "",
+		"HeaderAuthValue": "",
+		"MinimumPriority": "",
+		"CheckCert":       true,
+	},
+	"Telegram": {
+		"Token":           "",
+		"ChatID":          "",
+		"MinimumPriority": "",
+		"CheckCert":       true,
+	},
+	"Dynatrace": {
+		"APIToken":        "",
+		"APIUrl":          "",
+		"CheckCert":       true,
+		"MinimumPriority": "",
+	},
+	"Talon": {
+		"Address":         "",
+		"MinimumPriority": "",
+		"CheckCert":       true,
+	},
+}
+
+func init() {
+	for name, dst := range httpOutputDefaults {
+		// Apply common http output defaults to http output defaults
+		for k, v := range commonHttpOutputDefaults {
+			dst[k] = v
+		}
+
+		// Merge http outputs defaults with other outputs defaults
+		if _, ok := outputDefaults[name]; ok {
+			panic(fmt.Sprintf("key %v already set in the output defaults", name))
+		}
+		outputDefaults[name] = dst
+	}
+}
+
 func getConfig() *types.Configuration {
 	c := &types.Configuration{
 		Customfields:    make(map[string]string),
@@ -67,117 +458,12 @@ func getConfig() *types.Configuration {
 	v.SetDefault("TLSServer.CaCertFile", "/etc/certs/server/ca.crt")
 	v.SetDefault("TLSServer.NoTLSPort", 2810)
 
-	v.SetDefault("Slack.WebhookURL", "")
-	v.SetDefault("Slack.Footer", "https://github.com/falcosecurity/falcosidekick")
-	v.SetDefault("Slack.Username", "Falcosidekick")
-	v.SetDefault("Slack.Channel", "")
-	v.SetDefault("Slack.Icon", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
-	v.SetDefault("Slack.OutputFormat", "all")
-	v.SetDefault("Slack.MessageFormat", "")
-	v.SetDefault("Slack.MinimumPriority", "")
-	v.SetDefault("Slack.MutualTLS", false)
-	v.SetDefault("Slack.CheckCert", true)
-
-	v.SetDefault("Rocketchat.WebhookURL", "")
-	v.SetDefault("Rocketchat.Footer", "https://github.com/falcosecurity/falcosidekick")
-	v.SetDefault("Rocketchat.Username", "Falcosidekick")
-	v.SetDefault("Rocketchat.Icon", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
-	v.SetDefault("Rocketchat.OutputFormat", "all")
-	v.SetDefault("Rocketchat.MessageFormat", "")
-	v.SetDefault("Rocketchat.MinimumPriority", "")
-	v.SetDefault("Rocketchat.MutualTLS", false)
-	v.SetDefault("Rocketchat.CheckCert", true)
-
-	v.SetDefault("Mattermost.WebhookURL", "")
-	v.SetDefault("Mattermost.Footer", "https://github.com/falcosecurity/falcosidekick")
-	v.SetDefault("Mattermost.Username", "Falcosidekick")
-	v.SetDefault("Mattermost.Icon", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
-	v.SetDefault("Mattermost.OutputFormat", "all")
-	v.SetDefault("Mattermost.MessageFormat", "")
-	v.SetDefault("Mattermost.MinimumPriority", "")
-	v.SetDefault("Mattermost.MutualTLS", false)
-	v.SetDefault("Mattermost.CheckCert", true)
-
-	v.SetDefault("Teams.WebhookURL", "")
-	v.SetDefault("Teams.ActivityImage", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
-	v.SetDefault("Teams.OutputFormat", "all")
-	v.SetDefault("Teams.MinimumPriority", "")
-	v.SetDefault("Teams.MutualTLS", false)
-	v.SetDefault("Teams.CheckCert", true)
-
-	v.SetDefault("Datadog.APIKey", "")
-	v.SetDefault("Datadog.Host", "https://api.datadoghq.com")
-	v.SetDefault("Datadog.MinimumPriority", "")
-	v.SetDefault("Datadog.MutualTLS", false)
-	v.SetDefault("Datadog.CheckCert", true)
-
-	v.SetDefault("Discord.WebhookURL", "")
-	v.SetDefault("Discord.MinimumPriority", "")
-	v.SetDefault("Discord.Icon", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
-	v.SetDefault("Discord.MutualTLS", false)
-	v.SetDefault("Discord.CheckCert", true)
-
-	v.SetDefault("Alertmanager.HostPort", "")
-	v.SetDefault("Alertmanager.MinimumPriority", "")
-	v.SetDefault("Alertmanager.MutualTls", false)
-	v.SetDefault("Alertmanager.CheckCert", true)
-	v.SetDefault("Alertmanager.Endpoint", "/api/v1/alerts")
-	v.SetDefault("Alertmanager.ExpiresAfter", 0)
-	v.SetDefault("Alertmanager.DropEventDefaultPriority", "critical")
-	v.SetDefault("Alertmanager.DropEventThresholds", "10000:critical, 1000:critical, 100:critical, 10:warning, 1:warning")
-
-	v.SetDefault("Elasticsearch.HostPort", "")
-	v.SetDefault("Elasticsearch.Index", "falco")
-	v.SetDefault("Elasticsearch.Type", "_doc")
-	v.SetDefault("Elasticsearch.MinimumPriority", "")
-	v.SetDefault("Elasticsearch.Suffix", "daily")
-	v.SetDefault("Elasticsearch.MutualTls", false)
-	v.SetDefault("Elasticsearch.CheckCert", true)
-	v.SetDefault("Elasticsearch.Username", "")
-	v.SetDefault("Elasticsearch.Password", "")
-	v.SetDefault("Elasticsearch.FlattenFields", false)
-	v.SetDefault("Elasticsearch.CreateIndexTemplate", false)
-	v.SetDefault("Elasticsearch.NumberOfShards", 3)
-	v.SetDefault("Elasticsearch.NumberOfReplicas", 3)
-
-	v.SetDefault("Quickwit.HostPort", "")
-	v.SetDefault("Quickwit.Index", "falco")
-	v.SetDefault("Quickwit.ApiEndpoint", "api/v1")
-	v.SetDefault("Quickwit.Version", "0.7")
-	v.SetDefault("Quickwit.AutoCreateIndex", false)
-	v.SetDefault("Quickwit.MinimumPriority", "")
-	v.SetDefault("Quickwit.MutualTls", false)
-	v.SetDefault("Quickwit.CheckCert", true)
-
-	v.SetDefault("Influxdb.HostPort", "")
-	v.SetDefault("Influxdb.Database", "falco")
-	v.SetDefault("Influxdb.Organization", "")
-	v.SetDefault("Influxdb.Bucket", "falco")
-	v.SetDefault("Influxdb.Precision", "ns")
-	v.SetDefault("Influxdb.User", "")
-	v.SetDefault("Influxdb.Password", "")
-	v.SetDefault("Influxdb.Token", "")
-	v.SetDefault("Influxdb.MinimumPriority", "")
-	v.SetDefault("Influxdb.MutualTls", false)
-	v.SetDefault("Influxdb.CheckCert", true)
-
-	v.SetDefault("Loki.HostPort", "")
-	v.SetDefault("Loki.User", "")
-	v.SetDefault("Loki.APIKey", "")
-	v.SetDefault("Loki.MinimumPriority", "")
-	v.SetDefault("Loki.MutualTLS", false)
-	v.SetDefault("Loki.CheckCert", true)
-	v.SetDefault("Loki.Tenant", "")
-	v.SetDefault("Loki.Endpoint", "/loki/api/v1/push")
-	v.SetDefault("Loki.ExtraLabels", "")
-
-	v.SetDefault("SumoLogic.MinimumPriority", "")
-	v.SetDefault("SumoLogic.ReceiverURL", "")
-	v.SetDefault("SumoLogic.SourceCategory", "")
-	v.SetDefault("SumoLogic.SourceHost", "")
-	v.SetDefault("SumoLogic.Name", "")
-	v.SetDefault("SumoLogic.CheckCert", true)
-	v.SetDefault("SumoLogic.MutualTLS", false)
+	// Set outputs defaults
+	for prefix, m := range outputDefaults {
+		for key, val := range m {
+			v.SetDefault(prefix+"."+key, val)
+		}
+	}
 
 	v.SetDefault("AWS.AccessKeyID", "")
 	v.SetDefault("AWS.SecretAccessKey", "")
@@ -219,62 +505,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("AWS.Kinesis.StreamName", "")
 	v.SetDefault("AWS.Kinesis.MinimumPriority", "")
 
-	v.SetDefault("SMTP.HostPort", "")
-	v.SetDefault("SMTP.Tls", true)
-	v.SetDefault("SMTP.From", "")
-	v.SetDefault("SMTP.To", "")
-	v.SetDefault("SMTP.OutputFormat", "html")
-	v.SetDefault("SMTP.MinimumPriority", "")
-	v.SetDefault("SMTP.AuthMechanism", "plain")
-	v.SetDefault("SMTP.User", "")
-	v.SetDefault("SMTP.Password", "")
-	v.SetDefault("SMTP.Token", "")
-	v.SetDefault("SMTP.Identity", "")
-	v.SetDefault("SMTP.Trace", "")
-
-	v.SetDefault("STAN.HostPort", "")
-	v.SetDefault("STAN.ClusterID", "")
-	v.SetDefault("STAN.ClientID", "")
-	v.SetDefault("STAN.MutualTls", false)
-	v.SetDefault("STAN.CheckCert", true)
-
-	v.SetDefault("NATS.HostPort", "")
-	v.SetDefault("NATS.ClusterID", "")
-	v.SetDefault("NATS.ClientID", "")
-	v.SetDefault("NATS.MutualTls", false)
-	v.SetDefault("NATS.CheckCert", true)
-
-	v.SetDefault("Opsgenie.Region", "us")
-	v.SetDefault("Opsgenie.APIKey", "")
-	v.SetDefault("Opsgenie.MinimumPriority", "")
-	v.SetDefault("Opsgenie.MutualTLS", false)
-	v.SetDefault("Opsgenie.CheckCert", true)
-
-	v.SetDefault("Statsd.Forwarder", "")
-	v.SetDefault("Statsd.Namespace", "falcosidekick.")
-
 	v.SetDefault("Prometheus.ExtraLabels", "")
-
-	v.SetDefault("Dogstatsd.Forwarder", "")
-	v.SetDefault("Dogstatsd.Namespace", "falcosidekick.")
-	v.SetDefault("Dogstatsd.Tags", []string{})
-
-	v.SetDefault("Webhook.Address", "")
-	v.SetDefault("Webhook.Method", "POST")
-	v.SetDefault("Webhook.MinimumPriority", "")
-	v.SetDefault("Webhook.MutualTls", false)
-	v.SetDefault("Webhook.CheckCert", true)
-
-	v.SetDefault("NodeRed.Address", "")
-	v.SetDefault("NodeRed.User", "")
-	v.SetDefault("NodeRed.Password", "")
-	v.SetDefault("NodeRed.MinimumPriority", "")
-	v.SetDefault("NodeRed.CheckCert", true)
-
-	v.SetDefault("CloudEvents.Address", "")
-	v.SetDefault("CloudEvents.MinimumPriority", "")
-	v.SetDefault("CloudEvents.MutualTls", false)
-	v.SetDefault("CloudEvents.CheckCert", true)
 
 	v.SetDefault("Azure.eventHub.Namespace", "")
 	v.SetDefault("Azure.eventHub.Name", "")
@@ -297,118 +528,6 @@ func getConfig() *types.Configuration {
 	v.SetDefault("GCP.CloudRun.JWT", "")
 	v.SetDefault("GCP.CloudRun.MinimumPriority", "")
 
-	v.SetDefault("Googlechat.WebhookURL", "")
-	v.SetDefault("Googlechat.OutputFormat", "all")
-	v.SetDefault("Googlechat.MessageFormat", "")
-	v.SetDefault("Googlechat.MinimumPriority", "")
-	v.SetDefault("Googlechat.MutualTls", false)
-	v.SetDefault("Googlechat.CheckCert", true)
-
-	v.SetDefault("Cliq.WebhookURL", "")
-	v.SetDefault("Cliq.Icon", "https://raw.githubusercontent.com/falcosecurity/falcosidekick/master/imgs/falcosidekick_color.png")
-	v.SetDefault("Cliq.OutputFormat", "all")
-	v.SetDefault("Cliq.UseEmoji", false)
-	v.SetDefault("Cliq.MessageFormat", "")
-	v.SetDefault("Cliq.MinimumPriority", "")
-	v.SetDefault("Cliq.MutualTls", false)
-	v.SetDefault("Cliq.CheckCert", true)
-
-	v.SetDefault("Kafka.HostPort", "")
-	v.SetDefault("Kafka.Topic", "")
-	v.SetDefault("Kafka.MinimumPriority", "")
-	v.SetDefault("Kafka.SASL", "")
-	v.SetDefault("Kafka.TLS", false)
-	v.SetDefault("Kafka.Username", "")
-	v.SetDefault("Kafka.Password", "")
-	v.SetDefault("Kafka.Balancer", "round_robin")
-	v.SetDefault("Kafka.ClientID", "")
-	v.SetDefault("Kafka.Compression", "NONE")
-	v.SetDefault("Kafka.Async", false)
-	v.SetDefault("Kafka.RequiredACKs", "NONE")
-	v.SetDefault("Kafka.TopicCreation", false)
-
-	v.SetDefault("KafkaRest.Address", "")
-	v.SetDefault("KafkaRest.Version", 2)
-	v.SetDefault("KafkaRest.MinimumPriority", "")
-	v.SetDefault("KafkaRest.MutualTls", false)
-	v.SetDefault("KafkaRest.CheckCert", true)
-
-	v.SetDefault("Pagerduty.RoutingKey", "")
-	v.SetDefault("Pagerduty.Region", "us")
-	v.SetDefault("Pagerduty.MinimumPriority", "")
-	v.SetDefault("Pagerduty.MutualTls", false)
-	v.SetDefault("Pagerduty.CheckCert", true)
-
-	v.SetDefault("Kubeless.Namespace", "")
-	v.SetDefault("Kubeless.Function", "")
-	v.SetDefault("Kubeless.Port", 8080)
-	v.SetDefault("Kubeless.Kubeconfig", "")
-	v.SetDefault("Kubeless.MinimumPriority", "")
-	v.SetDefault("Kubeless.MutualTls", false)
-	v.SetDefault("Kubeless.CheckCert", true)
-
-	v.SetDefault("Openfaas.GatewayNamespace", "openfaas")
-	v.SetDefault("Openfaas.GatewayService", "gateway")
-	v.SetDefault("Openfaas.FunctionName", "")
-	v.SetDefault("Openfaas.FunctionNamespace", "openfaas-fn")
-	v.SetDefault("Openfaas.GatewayPort", 8080)
-	v.SetDefault("Openfaas.Kubeconfig", "")
-	v.SetDefault("Openfaas.MinimumPriority", "")
-	v.SetDefault("Openfaas.MutualTls", false)
-	v.SetDefault("Openfaas.CheckCert", true)
-
-	v.SetDefault("Fission.RouterNamespace", "fission")
-	v.SetDefault("Fission.RouterService", "router")
-	v.SetDefault("Fission.RouterPort", 80)
-	v.SetDefault("Fission.FunctionNamespace", "fission-function")
-	v.SetDefault("Fission.Function", "")
-	v.SetDefault("Fission.Kubeconfig", "")
-	v.SetDefault("Fission.MinimumPriority", "")
-	v.SetDefault("Fission.MutualTls", false)
-	v.SetDefault("Fission.CheckCert", true)
-
-	v.SetDefault("Webui.URL", "")
-	v.SetDefault("Webui.MutualTls", false)
-	v.SetDefault("Webui.CheckCert", true)
-
-	v.SetDefault("PolicyReport.Enabled", false)
-	v.SetDefault("PolicyReport.Kubeconfig", "")
-	v.SetDefault("PolicyReport.MinimumPriority", "")
-	v.SetDefault("PolicyReport.MaxEvents", 1000)
-	v.SetDefault("PolicyReport.FalcoNamespace", "")
-	v.SetDefault("PolicyReport.PruneByPriority", false)
-
-	v.SetDefault("Rabbitmq.URL", "")
-	v.SetDefault("Rabbitmq.Queue", "")
-	v.SetDefault("Rabbitmq.MinimumPriority", "")
-
-	v.SetDefault("Wavefront.EndpointType", "")
-	v.SetDefault("Wavefront.EndpointHost", "")
-	v.SetDefault("Wavefront.EndpointToken", "")
-	v.SetDefault("Wavefront.MetricName", "falco.alert")
-	v.SetDefault("Wavefront.EndpointMetricPort", 2878)
-	v.SetDefault("Wavefront.MinimumPriority", "")
-	v.SetDefault("Wavefront.FlushIntervalSecods", 1)
-	v.SetDefault("Wavefront.BatchSize", 10000)
-
-	v.SetDefault("Grafana.HostPort", "")
-	v.SetDefault("Grafana.DashboardID", 0)
-	v.SetDefault("Grafana.PanelID", 0)
-	v.SetDefault("Grafana.APIKey", "")
-	v.SetDefault("Grafana.AllFieldsAsTags", false)
-	v.SetDefault("Grafana.MinimumPriority", "")
-	v.SetDefault("Grafana.MutualTls", false)
-	v.SetDefault("Grafana.CheckCert", true)
-
-	v.SetDefault("GrafanaOnCall.WebhookURL", "")
-	v.SetDefault("GrafanaOnCall.MinimumPriority", "")
-	v.SetDefault("GrafanaOnCall.MutualTls", false)
-	v.SetDefault("GrafanaOnCall.CheckCert", true)
-
-	v.SetDefault("Grafana.MinimumPriority", "")
-	v.SetDefault("Grafana.MutualTls", false)
-	v.SetDefault("Grafana.CheckCert", true)
-
 	v.SetDefault("Yandex.AccessKeyID", "")
 	v.SetDefault("Yandex.SecretAccessKey", "")
 	v.SetDefault("Yandex.Region", "ru-central1")
@@ -421,89 +540,6 @@ func getConfig() *types.Configuration {
 	v.SetDefault("Yandex.DataStreams.Endpoint", "https://yds.serverless.yandexcloud.net")
 	v.SetDefault("Yandex.DataStreams.StreamName", "")
 	v.SetDefault("Yandex.DataStreams.MinimumPriority", "")
-
-	v.SetDefault("Syslog.Host", "")
-	v.SetDefault("Syslog.Port", "")
-	v.SetDefault("Syslog.Protocol", "")
-	v.SetDefault("Syslog.Format", "json")
-	v.SetDefault("Syslog.MinimumPriority", "")
-
-	v.SetDefault("MQTT.Broker", "")
-	v.SetDefault("MQTT.Topic", "falco/events")
-	v.SetDefault("MQTT.QOS", 0)
-	v.SetDefault("MQTT.Retained", false)
-	v.SetDefault("MQTT.User", "")
-	v.SetDefault("MQTT.Password", "")
-	v.SetDefault("MQTT.CheckCert", true)
-	v.SetDefault("MQTT.MinimumPriority", "")
-
-	v.SetDefault("Zincsearch.HostPort", "")
-	v.SetDefault("Zincsearch.Index", "falco")
-	v.SetDefault("Zincsearch.Username", "")
-	v.SetDefault("Zincsearch.Password", "")
-	v.SetDefault("Zincsearch.CheckCert", true)
-	v.SetDefault("Zincsearch.MinimumPriority", "")
-
-	v.SetDefault("Gotify.HostPort", "")
-	v.SetDefault("Gotify.Token", "")
-	v.SetDefault("Gotify.Format", "markdown")
-	v.SetDefault("Gotify.CheckCert", true)
-	v.SetDefault("Gotify.MinimumPriority", "")
-
-	v.SetDefault("Tekton.EventListener", "")
-	v.SetDefault("Tekton.MinimumPriority", "")
-	v.SetDefault("Tekton.CheckCert", true)
-
-	v.SetDefault("Spyderbat.OrgUID", "")
-	v.SetDefault("Spyderbat.APIKey", "")
-	v.SetDefault("Spyderbat.APIUrl", "https://api.spyderbat.com")
-	v.SetDefault("Spyderbat.Source", "falcosidekick")
-	v.SetDefault("Spyderbat.SourceDescription", "")
-	v.SetDefault("Spyderbat.MinimumPriority", "")
-
-	v.SetDefault("TimescaleDB.Host", "")
-	v.SetDefault("TimescaleDB.Port", "5432")
-	v.SetDefault("TimescaleDB.User", "postgres")
-	v.SetDefault("TimescaleDB.Password", "postgres")
-	v.SetDefault("TimescaleDB.Database", "falcosidekick")
-	v.SetDefault("TimescaleDB.HypertableName", "falcosidekick_events")
-	v.SetDefault("TimescaleDB.MinimumPriority", "")
-
-	v.SetDefault("Redis.Address", "")
-	v.SetDefault("Redis.Password", "")
-	v.SetDefault("Redis.Database", 0)
-	v.SetDefault("Redis.StorageType", "list")
-	v.SetDefault("Redis.Key", "falco")
-	v.SetDefault("Redis.MinimumPriority", "")
-	v.SetDefault("Redis.MutualTls", false)
-	v.SetDefault("Redis.CheckCert", true)
-
-	v.SetDefault("N8n.Address", "")
-	v.SetDefault("N8n.User", "")
-	v.SetDefault("N8n.Password", "")
-	v.SetDefault("N8n.HeaderAuthName", "")
-	v.SetDefault("N8n.HeaderAuthValue", "")
-	v.SetDefault("N8n.MinimumPriority", "")
-	v.SetDefault("N8n.CheckCert", true)
-
-	v.SetDefault("Telegram.Token", "")
-	v.SetDefault("Telegram.ChatID", "")
-	v.SetDefault("Telegram.MinimumPriority", "")
-	v.SetDefault("Telegram.CheckCert", true)
-
-	v.SetDefault("OpenObserve.HostPort", "")
-	v.SetDefault("OpenObserve.OrganizationName", "default")
-	v.SetDefault("OpenObserve.StreamName", "falco")
-	v.SetDefault("OpenObserve.MinimumPriority", "")
-	v.SetDefault("OpenObserve.MutualTls", false)
-	v.SetDefault("OpenObserve.CheckCert", true)
-	v.SetDefault("OpenObserve.Username", "")
-	v.SetDefault("OpenObserve.Password", "")
-
-	v.SetDefault("Dynatrace.APIToken", "")
-	v.SetDefault("Dynatrace.APIUrl", "")
-	v.SetDefault("Dynatrace.CheckCert", true)
-	v.SetDefault("Dynatrace.MinimumPriority", "")
 
 	v.SetDefault("OTLP.Traces.Endpoint", "")
 	v.SetDefault("OTLP.Traces.Protocol", "http/json")
@@ -519,10 +555,6 @@ func getConfig() *types.Configuration {
 	// NB: Unfortunately falco events don't provide endtime, artificially set
 	// it to 1000ms by default, override-able via OTLP_DURATION environment variable.
 	v.SetDefault("OTLP.Traces.Duration", 1000)
-
-	v.SetDefault("Talon.Address", "")
-	v.SetDefault("Talon.MinimumPriority", "")
-	v.SetDefault("Talon.CheckCert", true)
 
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/trace v1.28.0
 	golang.org/x/oauth2 v0.21.0
+	golang.org/x/sync v0.7.0
 	golang.org/x/text v0.16.0
 	google.golang.org/api v0.188.0
 	google.golang.org/genproto v0.0.0-20240708141625-4ad9e859172b
@@ -136,7 +137,6 @@ require (
 	golang.org/x/crypto v0.25.0 // indirect
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
 	golang.org/x/net v0.27.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func init() {
 
 	if config.Slack.WebhookURL != "" {
 		var err error
-		slackClient, err = outputs.NewClient("Slack", config.Slack.WebhookURL, config.Slack.MutualTLS, config.Slack.CheckCert, *initClientArgs)
+		slackClient, err = outputs.NewClient("Slack", config.Slack.WebhookURL, config.Slack.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Slack.WebhookURL = ""
 		} else {
@@ -157,7 +157,7 @@ func init() {
 
 	if config.Cliq.WebhookURL != "" {
 		var err error
-		cliqClient, err = outputs.NewClient("Cliq", config.Cliq.WebhookURL, config.Cliq.MutualTLS, config.Cliq.CheckCert, *initClientArgs)
+		cliqClient, err = outputs.NewClient("Cliq", config.Cliq.WebhookURL, config.Cliq.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Cliq.WebhookURL = ""
 		} else {
@@ -167,7 +167,7 @@ func init() {
 
 	if config.Rocketchat.WebhookURL != "" {
 		var err error
-		rocketchatClient, err = outputs.NewClient("Rocketchat", config.Rocketchat.WebhookURL, config.Rocketchat.MutualTLS, config.Rocketchat.CheckCert, *initClientArgs)
+		rocketchatClient, err = outputs.NewClient("Rocketchat", config.Rocketchat.WebhookURL, config.Rocketchat.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Rocketchat.WebhookURL = ""
 		} else {
@@ -177,7 +177,7 @@ func init() {
 
 	if config.Mattermost.WebhookURL != "" {
 		var err error
-		mattermostClient, err = outputs.NewClient("Mattermost", config.Mattermost.WebhookURL, config.Mattermost.MutualTLS, config.Mattermost.CheckCert, *initClientArgs)
+		mattermostClient, err = outputs.NewClient("Mattermost", config.Mattermost.WebhookURL, config.Mattermost.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Mattermost.WebhookURL = ""
 		} else {
@@ -187,7 +187,7 @@ func init() {
 
 	if config.Teams.WebhookURL != "" {
 		var err error
-		teamsClient, err = outputs.NewClient("Teams", config.Teams.WebhookURL, config.Teams.MutualTLS, config.Teams.CheckCert, *initClientArgs)
+		teamsClient, err = outputs.NewClient("Teams", config.Teams.WebhookURL, config.Teams.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Teams.WebhookURL = ""
 		} else {
@@ -198,7 +198,7 @@ func init() {
 	if config.Datadog.APIKey != "" {
 		var err error
 		endpointUrl := fmt.Sprintf("%s?api_key=%s", config.Datadog.Host+outputs.DatadogPath, config.Datadog.APIKey)
-		datadogClient, err = outputs.NewClient("Datadog", endpointUrl, config.Datadog.MutualTLS, config.Datadog.CheckCert, *initClientArgs)
+		datadogClient, err = outputs.NewClient("Datadog", endpointUrl, config.Datadog.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Datadog.APIKey = ""
 		} else {
@@ -208,7 +208,7 @@ func init() {
 
 	if config.Discord.WebhookURL != "" {
 		var err error
-		discordClient, err = outputs.NewClient("Discord", config.Discord.WebhookURL, config.Discord.MutualTLS, config.Discord.CheckCert, *initClientArgs)
+		discordClient, err = outputs.NewClient("Discord", config.Discord.WebhookURL, config.Discord.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Discord.WebhookURL = ""
 		} else {
@@ -219,7 +219,7 @@ func init() {
 	if config.Alertmanager.HostPort != "" {
 		var err error
 		endpointUrl := fmt.Sprintf("%s%s", config.Alertmanager.HostPort, config.Alertmanager.Endpoint)
-		alertmanagerClient, err = outputs.NewClient("AlertManager", endpointUrl, config.Alertmanager.MutualTLS, config.Alertmanager.CheckCert, *initClientArgs)
+		alertmanagerClient, err = outputs.NewClient("AlertManager", endpointUrl, config.Alertmanager.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Alertmanager.HostPort = ""
 		} else {
@@ -230,7 +230,7 @@ func init() {
 	if config.Elasticsearch.HostPort != "" {
 		var err error
 		endpointUrl := fmt.Sprintf("%s/%s/%s", config.Elasticsearch.HostPort, config.Elasticsearch.Index, config.Elasticsearch.Type)
-		elasticsearchClient, err = outputs.NewClient("Elasticsearch", endpointUrl, config.Elasticsearch.MutualTLS, config.Elasticsearch.CheckCert, *initClientArgs)
+		elasticsearchClient, err = outputs.NewClient("Elasticsearch", endpointUrl, config.Elasticsearch.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Elasticsearch.HostPort = ""
 		} else {
@@ -251,7 +251,7 @@ func init() {
 		var err error
 
 		endpointUrl := fmt.Sprintf("%s/%s/%s/ingest", config.Quickwit.HostPort, config.Quickwit.ApiEndpoint, config.Quickwit.Index)
-		quickwitClient, err = outputs.NewClient("Quickwit", endpointUrl, config.Quickwit.MutualTLS, config.Quickwit.CheckCert, *initClientArgs)
+		quickwitClient, err = outputs.NewClient("Quickwit", endpointUrl, config.Quickwit.CommonConfig, *initClientArgs)
 		if err == nil && config.Quickwit.AutoCreateIndex {
 			err = quickwitClient.AutoCreateQuickwitIndex(*initClientArgs)
 		}
@@ -265,7 +265,7 @@ func init() {
 
 	if config.Loki.HostPort != "" {
 		var err error
-		lokiClient, err = outputs.NewClient("Loki", config.Loki.HostPort+config.Loki.Endpoint, config.Loki.MutualTLS, config.Loki.CheckCert, *initClientArgs)
+		lokiClient, err = outputs.NewClient("Loki", config.Loki.HostPort+config.Loki.Endpoint, config.Loki.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Loki.HostPort = ""
 		} else {
@@ -275,7 +275,7 @@ func init() {
 
 	if config.SumoLogic.ReceiverURL != "" {
 		var err error
-		sumologicClient, err = outputs.NewClient("SumoLogic", config.SumoLogic.ReceiverURL, false, config.SumoLogic.CheckCert, *initClientArgs)
+		sumologicClient, err = outputs.NewClient("SumoLogic", config.SumoLogic.ReceiverURL, config.SumoLogic.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.SumoLogic.ReceiverURL = ""
 		} else {
@@ -285,7 +285,7 @@ func init() {
 
 	if config.Nats.HostPort != "" {
 		var err error
-		natsClient, err = outputs.NewClient("NATS", config.Nats.HostPort, config.Nats.MutualTLS, config.Nats.CheckCert, *initClientArgs)
+		natsClient, err = outputs.NewClient("NATS", config.Nats.HostPort, config.Nats.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Nats.HostPort = ""
 		} else {
@@ -295,7 +295,7 @@ func init() {
 
 	if config.Stan.HostPort != "" && config.Stan.ClusterID != "" && config.Stan.ClientID != "" {
 		var err error
-		stanClient, err = outputs.NewClient("STAN", config.Stan.HostPort, config.Stan.MutualTLS, config.Stan.CheckCert, *initClientArgs)
+		stanClient, err = outputs.NewClient("STAN", config.Stan.HostPort, config.Stan.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Stan.HostPort = ""
 			config.Stan.ClusterID = ""
@@ -320,7 +320,7 @@ func init() {
 		}
 
 		var err error
-		influxdbClient, err = outputs.NewClient("Influxdb", url, config.Influxdb.MutualTLS, config.Influxdb.CheckCert, *initClientArgs)
+		influxdbClient, err = outputs.NewClient("Influxdb", url, config.Influxdb.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Influxdb.HostPort = ""
 		} else {
@@ -402,7 +402,7 @@ func init() {
 		if strings.ToLower(config.Opsgenie.Region) == "eu" {
 			url = "https://api.eu.opsgenie.com/v2/alerts"
 		}
-		opsgenieClient, err = outputs.NewClient("Opsgenie", url, config.Opsgenie.MutualTLS, config.Opsgenie.CheckCert, *initClientArgs)
+		opsgenieClient, err = outputs.NewClient("Opsgenie", url, config.Opsgenie.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Opsgenie.APIKey = ""
 		} else {
@@ -412,7 +412,7 @@ func init() {
 
 	if config.Webhook.Address != "" {
 		var err error
-		webhookClient, err = outputs.NewClient("Webhook", config.Webhook.Address, config.Webhook.MutualTLS, config.Webhook.CheckCert, *initClientArgs)
+		webhookClient, err = outputs.NewClient("Webhook", config.Webhook.Address, config.Webhook.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Webhook.Address = ""
 		} else {
@@ -422,7 +422,7 @@ func init() {
 
 	if config.NodeRed.Address != "" {
 		var err error
-		noderedClient, err = outputs.NewClient("NodeRed", config.NodeRed.Address, false, config.NodeRed.CheckCert, *initClientArgs)
+		noderedClient, err = outputs.NewClient("NodeRed", config.NodeRed.Address, config.NodeRed.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.NodeRed.Address = ""
 		} else {
@@ -432,7 +432,7 @@ func init() {
 
 	if config.CloudEvents.Address != "" {
 		var err error
-		cloudeventsClient, err = outputs.NewClient("CloudEvents", config.CloudEvents.Address, config.CloudEvents.MutualTLS, config.CloudEvents.CheckCert, *initClientArgs)
+		cloudeventsClient, err = outputs.NewClient("CloudEvents", config.CloudEvents.Address, config.CloudEvents.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.CloudEvents.Address = ""
 		} else {
@@ -478,7 +478,7 @@ func init() {
 		var err error
 		var outputName = "GCPCloudRun"
 
-		gcpCloudRunClient, err = outputs.NewClient(outputName, config.GCP.CloudRun.Endpoint, false, false, *initClientArgs)
+		gcpCloudRunClient, err = outputs.NewClient(outputName, config.GCP.CloudRun.Endpoint, types.CommonConfig{}, *initClientArgs)
 
 		if err != nil {
 			config.GCP.CloudRun.Endpoint = ""
@@ -489,7 +489,7 @@ func init() {
 
 	if config.Googlechat.WebhookURL != "" {
 		var err error
-		googleChatClient, err = outputs.NewClient("Googlechat", config.Googlechat.WebhookURL, config.Googlechat.MutualTLS, config.Googlechat.CheckCert, *initClientArgs)
+		googleChatClient, err = outputs.NewClient("Googlechat", config.Googlechat.WebhookURL, config.Googlechat.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Googlechat.WebhookURL = ""
 		} else {
@@ -509,7 +509,7 @@ func init() {
 
 	if config.KafkaRest.Address != "" {
 		var err error
-		kafkaRestClient, err = outputs.NewClient("KafkaRest", config.KafkaRest.Address, config.KafkaRest.MutualTLS, config.KafkaRest.CheckCert, *initClientArgs)
+		kafkaRestClient, err = outputs.NewClient("KafkaRest", config.KafkaRest.Address, config.KafkaRest.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.KafkaRest.Address = ""
 		} else {
@@ -522,7 +522,7 @@ func init() {
 		var url = "https://events.pagerduty.com/v2/enqueue"
 		var outputName = "Pagerduty"
 
-		pagerdutyClient, err = outputs.NewClient(outputName, url, config.Pagerduty.MutualTLS, config.Pagerduty.CheckCert, *initClientArgs)
+		pagerdutyClient, err = outputs.NewClient(outputName, url, config.Pagerduty.CommonConfig, *initClientArgs)
 
 		if err != nil {
 			config.Pagerduty.RoutingKey = ""
@@ -545,7 +545,7 @@ func init() {
 
 	if config.WebUI.URL != "" {
 		var err error
-		webUIClient, err = outputs.NewClient("WebUI", config.WebUI.URL, config.WebUI.MutualTLS, config.WebUI.CheckCert, *initClientArgs)
+		webUIClient, err = outputs.NewClient("WebUI", config.WebUI.URL, config.WebUI.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.WebUI.URL = ""
 		} else {
@@ -575,7 +575,7 @@ func init() {
 
 	if config.Tekton.EventListener != "" {
 		var err error
-		tektonClient, err = outputs.NewClient("Tekton", config.Tekton.EventListener, config.Tekton.MutualTLS, config.Tekton.CheckCert, *initClientArgs)
+		tektonClient, err = outputs.NewClient("Tekton", config.Tekton.EventListener, config.Tekton.CommonConfig, *initClientArgs)
 		if err != nil {
 			log.Printf("[ERROR] : Tekton - %v\n", err)
 		} else {
@@ -618,7 +618,7 @@ func init() {
 		var err error
 		var outputName = "Grafana"
 		endpointUrl := fmt.Sprintf("%s/api/annotations", config.Grafana.HostPort)
-		grafanaClient, err = outputs.NewClient(outputName, endpointUrl, config.Grafana.MutualTLS, config.Grafana.CheckCert, *initClientArgs)
+		grafanaClient, err = outputs.NewClient(outputName, endpointUrl, config.Grafana.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.Grafana.HostPort = ""
 			config.Grafana.APIKey = ""
@@ -630,7 +630,7 @@ func init() {
 	if config.GrafanaOnCall.WebhookURL != "" {
 		var err error
 		var outputName = "GrafanaOnCall"
-		grafanaOnCallClient, err = outputs.NewClient(outputName, config.GrafanaOnCall.WebhookURL, config.GrafanaOnCall.MutualTLS, config.GrafanaOnCall.CheckCert, *initClientArgs)
+		grafanaOnCallClient, err = outputs.NewClient(outputName, config.GrafanaOnCall.WebhookURL, config.GrafanaOnCall.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.GrafanaOnCall.WebhookURL = ""
 		} else {
@@ -689,7 +689,7 @@ func init() {
 	if config.Zincsearch.HostPort != "" {
 		var err error
 		endpointUrl := fmt.Sprintf("%s/api/%s/_doc", config.Zincsearch.HostPort, config.Zincsearch.Index)
-		zincsearchClient, err = outputs.NewClient("Zincsearch", endpointUrl, false, config.Zincsearch.CheckCert, *initClientArgs)
+		zincsearchClient, err = outputs.NewClient("Zincsearch", endpointUrl, types.CommonConfig{CheckCert: config.Zincsearch.CheckCert}, *initClientArgs)
 		if err != nil {
 			config.Zincsearch.HostPort = ""
 		} else {
@@ -700,7 +700,7 @@ func init() {
 	if config.Gotify.HostPort != "" {
 		var err error
 		endpointUrl := fmt.Sprintf("%s/message", config.Gotify.HostPort)
-		gotifyClient, err = outputs.NewClient("Gotify", endpointUrl, false, config.Gotify.CheckCert, *initClientArgs)
+		gotifyClient, err = outputs.NewClient("Gotify", endpointUrl, types.CommonConfig{CheckCert: config.Gotify.CheckCert}, *initClientArgs)
 		if err != nil {
 			config.Gotify.HostPort = ""
 		} else {
@@ -744,7 +744,7 @@ func init() {
 		var err error
 		var urlFormat = "https://api.telegram.org/bot%s/sendMessage"
 
-		telegramClient, err = outputs.NewClient("Telegram", fmt.Sprintf(urlFormat, config.Telegram.Token), false, config.Telegram.CheckCert, *initClientArgs)
+		telegramClient, err = outputs.NewClient("Telegram", fmt.Sprintf(urlFormat, config.Telegram.Token), types.CommonConfig{CheckCert: config.Telegram.CheckCert}, *initClientArgs)
 
 		if err != nil {
 			config.Telegram.ChatID = ""
@@ -758,7 +758,7 @@ func init() {
 
 	if config.N8N.Address != "" {
 		var err error
-		n8nClient, err = outputs.NewClient("n8n", config.N8N.Address, false, config.N8N.CheckCert, *initClientArgs)
+		n8nClient, err = outputs.NewClient("n8n", config.N8N.Address, types.CommonConfig{CheckCert: config.N8N.CheckCert}, *initClientArgs)
 		if err != nil {
 			config.N8N.Address = ""
 		} else {
@@ -769,7 +769,7 @@ func init() {
 	if config.OpenObserve.HostPort != "" {
 		var err error
 		endpointUrl := fmt.Sprintf("%s/api/%s/%s/_multi", config.OpenObserve.HostPort, config.OpenObserve.OrganizationName, config.OpenObserve.StreamName)
-		openObserveClient, err = outputs.NewClient("OpenObserve", endpointUrl, config.OpenObserve.MutualTLS, config.OpenObserve.CheckCert, *initClientArgs)
+		openObserveClient, err = outputs.NewClient("OpenObserve", endpointUrl, config.OpenObserve.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.OpenObserve.HostPort = ""
 		} else {
@@ -780,7 +780,7 @@ func init() {
 	if config.Dynatrace.APIToken != "" && config.Dynatrace.APIUrl != "" {
 		var err error
 		dynatraceApiUrl := strings.TrimRight(config.Dynatrace.APIUrl, "/") + "/v2/logs/ingest"
-		dynatraceClient, err = outputs.NewClient("Dynatrace", dynatraceApiUrl, false, config.Dynatrace.CheckCert, *initClientArgs)
+		dynatraceClient, err = outputs.NewClient("Dynatrace", dynatraceApiUrl, types.CommonConfig{CheckCert: config.Dynatrace.CheckCert}, *initClientArgs)
 		if err != nil {
 			config.Dynatrace.APIToken = ""
 			config.Dynatrace.APIUrl = ""
@@ -802,7 +802,7 @@ func init() {
 
 	if config.Talon.Address != "" {
 		var err error
-		talonClient, err = outputs.NewClient("Talon", config.Talon.Address, false, config.Talon.CheckCert, *initClientArgs)
+		talonClient, err = outputs.NewClient("Talon", config.Talon.Address, types.CommonConfig{CheckCert: config.Talon.CheckCert}, *initClientArgs)
 		if err != nil {
 			config.Talon.Address = ""
 		} else {

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -296,7 +296,7 @@ func (c *Client) sendRequest(method string, payload interface{}, opts ...Request
 		msg := getInlinedBodyAsString(resp)
 		log.Printf("[ERROR] : %v - %v (%v): %s\n", c.OutputType, ErrHeaderMissing, resp.StatusCode, msg)
 		if msg != "" {
-			return fmt.Errorf(msg)
+			return errors.New(msg)
 		}
 		return ErrHeaderMissing
 	case http.StatusUnauthorized: //401

--- a/outputs/cliq.go
+++ b/outputs/cliq.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/falcosecurity/falcosidekick/types"
 )
@@ -164,10 +165,9 @@ func newCliqPayload(falcopayload types.FalcoPayload, config *types.Configuration
 func (c *Client) CliqPost(falcopayload types.FalcoPayload) {
 	c.Stats.Cliq.Add(Total, 1)
 
-	c.httpClientLock.Lock()
-	defer c.httpClientLock.Unlock()
-	c.AddHeader(ContentTypeHeaderKey, "application/json")
-	err := c.Post(newCliqPayload(falcopayload, c.Config))
+	err := c.Post(newCliqPayload(falcopayload, c.Config), func(req *http.Request) {
+		req.Header.Set(ContentTypeHeaderKey, "application/json")
+	})
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:cliq", "status:error"})
 		c.Stats.Cliq.Add(Error, 1)

--- a/outputs/dynatrace.go
+++ b/outputs/dynatrace.go
@@ -4,6 +4,7 @@ package outputs
 
 import (
 	"log"
+	"net/http"
 	"regexp"
 	"strconv"
 	"time"
@@ -114,11 +115,9 @@ func (c *Client) DynatracePost(falcopayload types.FalcoPayload) {
 
 	c.ContentType = DynatraceContentType
 
-	c.httpClientLock.Lock()
-	defer c.httpClientLock.Unlock()
-	c.AddHeader("Authorization", "Api-Token "+c.Config.Dynatrace.APIToken)
-
-	err := c.Post(newDynatracePayload(falcopayload).Payload)
+	err := c.Post(newDynatracePayload(falcopayload).Payload, func(req *http.Request) {
+		req.Header.Set("Authorization", "Api-Token "+c.Config.Dynatrace.APIToken)
+	})
 	if err != nil {
 		go c.CountMetric(Outputs, 1, []string{"output:dynatrace", "status:error"})
 		c.Stats.Dynatrace.Add(Error, 1)

--- a/outputs/openfaas.go
+++ b/outputs/openfaas.go
@@ -48,7 +48,7 @@ func NewOpenfaasClient(config *types.Configuration, stats *types.Statistics, pro
 		StatsdClient:    statsdClient,
 	}
 
-	return NewClient(Openfaas, endpointUrl, config.Openfaas.MutualTLS, config.Openfaas.CheckCert, *initClientArgs)
+	return NewClient(Openfaas, endpointUrl, config.Openfaas.CommonConfig, *initClientArgs)
 }
 
 // OpenfaasCall .

--- a/outputs/otlp.go
+++ b/outputs/otlp.go
@@ -29,7 +29,7 @@ func NewOtlpTracesClient(config *types.Configuration, stats *types.Statistics, p
 		PromStats:       promStats,
 		StatsdClient:    statsdClient,
 	}
-	otlpClient, err := NewClient("OTLPTraces", config.OTLP.Traces.Endpoint, false, false, *initClientArgs)
+	otlpClient, err := NewClient("OTLPTraces", config.OTLP.Traces.Endpoint, types.CommonConfig{}, *initClientArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/outputs/otlp_test.go
+++ b/outputs/otlp_test.go
@@ -91,7 +91,7 @@ func TestOtlpNewTrace(t *testing.T) {
 			PromStats: promStats,
 		}
 
-		client, _ := NewClient("OTLP", "http://localhost:4317", false, false, *initClientArgs)
+		client, _ := NewClient("OTLP", "http://localhost:4317", types.CommonConfig{}, *initClientArgs)
 		// Test newTrace()
 		span, err := client.newTrace(c.fp)
 		require.Nil(t, err)

--- a/outputs/sumologic.go
+++ b/outputs/sumologic.go
@@ -4,6 +4,7 @@ package outputs
 
 import (
 	"log"
+	"net/http"
 	"net/url"
 
 	"github.com/falcosecurity/falcosidekick/types"
@@ -22,19 +23,20 @@ func (c *Client) SumoLogicPost(falcopayload types.FalcoPayload) {
 
 	c.EndpointURL = endpointURL
 
-	if c.Config.SumoLogic.SourceCategory != "" {
-		c.AddHeader("X-Sumo-Category", c.Config.SumoLogic.SourceCategory)
-	}
+	err = c.Post(falcopayload, func(req *http.Request) {
+		if c.Config.SumoLogic.SourceCategory != "" {
+			req.Header.Set("X-Sumo-Category", c.Config.SumoLogic.SourceCategory)
+		}
 
-	if c.Config.SumoLogic.SourceHost != "" {
-		c.AddHeader("X-Sumo-Host", c.Config.SumoLogic.SourceHost)
-	}
+		if c.Config.SumoLogic.SourceHost != "" {
+			req.Header.Set("X-Sumo-Host", c.Config.SumoLogic.SourceHost)
+		}
 
-	if c.Config.SumoLogic.Name != "" {
-		c.AddHeader("X-Sumo-Name", c.Config.SumoLogic.Name)
-	}
+		if c.Config.SumoLogic.Name != "" {
+			req.Header.Set("X-Sumo-Name", c.Config.SumoLogic.Name)
+		}
+	})
 
-	err = c.Post(falcopayload)
 	if err != nil {
 		c.setSumoLogicErrorMetrics()
 		log.Printf("[ERROR] : %x - %v\n", c.OutputType, err)

--- a/outputs/webhook.go
+++ b/outputs/webhook.go
@@ -4,6 +4,7 @@ package outputs
 
 import (
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/falcosecurity/falcosidekick/types"
@@ -13,18 +14,16 @@ import (
 func (c *Client) WebhookPost(falcopayload types.FalcoPayload) {
 	c.Stats.Webhook.Add(Total, 1)
 
-	if len(c.Config.Webhook.CustomHeaders) != 0 {
-		c.httpClientLock.Lock()
-		defer c.httpClientLock.Unlock()
+	optfn := func(req *http.Request) {
 		for i, j := range c.Config.Webhook.CustomHeaders {
-			c.AddHeader(i, j)
+			req.Header.Set(i, j)
 		}
 	}
 	var err error
 	if strings.ToUpper(c.Config.Webhook.Method) == HttpPut {
-		err = c.Put(falcopayload)
+		err = c.Put(falcopayload, optfn)
 	} else {
-		err = c.Post(falcopayload)
+		err = c.Post(falcopayload, optfn)
 	}
 
 	if err != nil {

--- a/outputs/zincsearch.go
+++ b/outputs/zincsearch.go
@@ -3,8 +3,8 @@
 package outputs
 
 import (
-	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/falcosecurity/falcosidekick/types"
 )
@@ -13,14 +13,11 @@ import (
 func (c *Client) ZincsearchPost(falcopayload types.FalcoPayload) {
 	c.Stats.Zincsearch.Add(Total, 1)
 
-	if c.Config.Zincsearch.Username != "" && c.Config.Zincsearch.Password != "" {
-		c.httpClientLock.Lock()
-		defer c.httpClientLock.Unlock()
-		c.BasicAuth(c.Config.Zincsearch.Username, c.Config.Zincsearch.Password)
-	}
-
-	fmt.Println(c.EndpointURL)
-	err := c.Post(falcopayload)
+	err := c.Post(falcopayload, func(req *http.Request) {
+		if c.Config.Zincsearch.Username != "" && c.Config.Zincsearch.Password != "" {
+			req.SetBasicAuth(c.Config.Zincsearch.Username, c.Config.Zincsearch.Password)
+		}
+	})
 	if err != nil {
 		c.setZincsearchErrorMetrics()
 		log.Printf("[ERROR] : Zincsearch - %v\n", err)

--- a/types/types.go
+++ b/types/types.go
@@ -149,8 +149,15 @@ type TLSServer struct {
 	NoTLSPaths []string
 }
 
+type CommonConfig struct {
+	CheckCert             bool
+	MutualTLS             bool
+	MaxConcurrentRequests uint16 // Max concurrent requests at a time, unlimited if 0
+}
+
 // SlackOutputConfig represents parameters for Slack
 type SlackOutputConfig struct {
+	CommonConfig          `mapstructure:",squash"`
 	WebhookURL            string
 	Channel               string
 	Footer                string
@@ -160,12 +167,11 @@ type SlackOutputConfig struct {
 	MinimumPriority       string
 	MessageFormat         string
 	MessageFormatTemplate *template.Template
-	CheckCert             bool
-	MutualTLS             bool
 }
 
 // CliqOutputConfig represents parameters for Zoho Cliq
 type CliqOutputConfig struct {
+	CommonConfig          `mapstructure:",squash"`
 	WebhookURL            string
 	Icon                  string
 	OutputFormat          string
@@ -173,12 +179,11 @@ type CliqOutputConfig struct {
 	MessageFormat         string
 	MessageFormatTemplate *template.Template
 	UseEmoji              bool
-	CheckCert             bool
-	MutualTLS             bool
 }
 
 // RocketchatOutputConfig .
 type RocketchatOutputConfig struct {
+	CommonConfig          `mapstructure:",squash"`
 	WebhookURL            string
 	Footer                string
 	Icon                  string
@@ -187,12 +192,11 @@ type RocketchatOutputConfig struct {
 	MinimumPriority       string
 	MessageFormat         string
 	MessageFormatTemplate *template.Template
-	CheckCert             bool
-	MutualTLS             bool
 }
 
 // MattermostOutputConfig represents parameters for Mattermost
 type MattermostOutputConfig struct {
+	CommonConfig          `mapstructure:",squash"`
 	WebhookURL            string
 	Footer                string
 	Icon                  string
@@ -201,8 +205,6 @@ type MattermostOutputConfig struct {
 	MinimumPriority       string
 	MessageFormat         string
 	MessageFormatTemplate *template.Template
-	CheckCert             bool
-	MutualTLS             bool
 }
 
 type WavefrontOutputConfig struct {
@@ -217,29 +219,26 @@ type WavefrontOutputConfig struct {
 }
 
 type teamsOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	WebhookURL      string
 	ActivityImage   string
 	OutputFormat    string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type datadogOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	APIKey          string
 	Host            string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 // DiscordOutputConfig .
 type DiscordOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	WebhookURL      string
 	MinimumPriority string
 	Icon            string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type ThresholdConfig struct {
@@ -248,10 +247,9 @@ type ThresholdConfig struct {
 }
 
 type AlertmanagerOutputConfig struct {
+	CommonConfig             `mapstructure:",squash"`
 	HostPort                 string
 	MinimumPriority          string
-	CheckCert                bool
-	MutualTLS                bool
 	Endpoint                 string
 	ExpiresAfter             int
 	ExtraLabels              map[string]string
@@ -264,6 +262,7 @@ type AlertmanagerOutputConfig struct {
 }
 
 type ElasticsearchOutputConfig struct {
+	CommonConfig        `mapstructure:",squash"`
 	HostPort            string
 	Index               string
 	Type                string
@@ -275,24 +274,22 @@ type ElasticsearchOutputConfig struct {
 	CreateIndexTemplate bool
 	NumberOfShards      int
 	NumberOfReplicas    int
-	CheckCert           bool
-	MutualTLS           bool
 	CustomHeaders       map[string]string
 }
 
 type QuickwitOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	HostPort        string
 	ApiEndpoint     string
 	Index           string
 	Version         string
 	CustomHeaders   map[string]string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 	AutoCreateIndex bool
 }
 
 type influxdbOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	HostPort        string
 	Database        string
 	Organization    string
@@ -302,17 +299,14 @@ type influxdbOutputConfig struct {
 	Password        string
 	Token           string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type LokiOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	HostPort        string
 	User            string
 	APIKey          string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 	Tenant          string
 	Endpoint        string
 	ExtraLabels     string
@@ -321,13 +315,12 @@ type LokiOutputConfig struct {
 }
 
 type SumoLogicOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	MinimumPriority string
 	ReceiverURL     string
 	SourceCategory  string
 	SourceHost      string
 	Name            string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type prometheusOutputConfig struct {
@@ -336,19 +329,17 @@ type prometheusOutputConfig struct {
 }
 
 type natsOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	HostPort        string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type stanOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	HostPort        string
 	ClusterID       string
 	ClientID        string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type awsOutputConfig struct {
@@ -434,40 +425,37 @@ type smtpOutputConfig struct {
 }
 
 type opsgenieOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	Region          string
 	APIKey          string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 // WebhookOutputConfig represents parameters for Webhook
 type WebhookOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	Address         string
 	Method          string
 	CustomHeaders   map[string]string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 // NodeRedOutputConfig represents parameters for Node-RED
 type NodeRedOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	Address         string
 	User            string
 	Password        string
 	CustomHeaders   map[string]string
 	MinimumPriority string
-	CheckCert       bool
 }
 
 // CloudEventsOutputConfig represents parameters for CloudEvents
 type CloudEventsOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	Address         string
 	Extensions      map[string]string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type statsdOutputConfig struct {
@@ -521,13 +509,12 @@ type gcpStorage struct {
 
 // GooglechatConfig represents parameters for Google chat
 type GooglechatConfig struct {
+	CommonConfig          `mapstructure:",squash"`
 	WebhookURL            string
 	OutputFormat          string
 	MinimumPriority       string
 	MessageFormat         string
 	MessageFormatTemplate *template.Template
-	CheckCert             bool
-	MutualTLS             bool
 }
 
 type kafkaConfig struct {
@@ -547,32 +534,30 @@ type kafkaConfig struct {
 }
 
 type KafkaRestConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	Address         string
 	Version         int
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type PagerdutyConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	RoutingKey      string
 	Region          string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type kubelessConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	Namespace       string
 	Function        string
 	Port            int
 	Kubeconfig      string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 type openfaasConfig struct {
+	CommonConfig      `mapstructure:",squash"`
 	GatewayNamespace  string
 	GatewayService    string
 	FunctionName      string
@@ -580,22 +565,18 @@ type openfaasConfig struct {
 	GatewayPort       int
 	Kubeconfig        string
 	MinimumPriority   string
-	CheckCert         bool
-	MutualTLS         bool
 }
 
 type tektonConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	EventListener   string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 // WebUIOutputConfig represents parameters for WebUI
 type WebUIOutputConfig struct {
-	URL       string
-	CheckCert bool
-	MutualTLS bool
+	CommonConfig `mapstructure:",squash"`
+	URL          string
 }
 
 // PolicyReportConfig represents parameters for policyreport
@@ -617,22 +598,20 @@ type RabbitmqConfig struct {
 
 // GrafanaOutputConfig represents parameters for Grafana
 type GrafanaOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	HostPort        string
 	APIKey          string
 	DashboardID     int
 	PanelID         int
 	AllFieldsAsTags bool
-	CheckCert       bool
-	MutualTLS       bool
 	MinimumPriority string
 	CustomHeaders   map[string]string
 }
 
 // GrafanaOnCallOutputConfig represents parameters for Grafana OnCall
 type GrafanaOnCallOutputConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	WebhookURL      string
-	CheckCert       bool
-	MutualTLS       bool
 	MinimumPriority string
 	CustomHeaders   map[string]string
 }
@@ -682,14 +661,13 @@ type MQTTConfig struct {
 
 // fissionConfig represents config parameters for Fission
 type fissionConfig struct {
+	CommonConfig    `mapstructure:",squash"`
 	RouterNamespace string
 	RouterService   string
 	RouterPort      int
 	Function        string
 	KubeConfig      string
 	MinimumPriority string
-	CheckCert       bool
-	MutualTLS       bool
 }
 
 // zincsearchOutputConfig represents config parameters for Zincsearch
@@ -771,14 +749,13 @@ type DynatraceOutputConfig struct {
 
 // OpenObserveConfig represents config parameters for OpenObserve
 type OpenObserveConfig struct {
+	CommonConfig     `mapstructure:",squash"`
 	HostPort         string
 	OrganizationName string
 	StreamName       string
 	MinimumPriority  string
 	Username         string
 	Password         string
-	CheckCert        bool
-	MutualTLS        bool
 	CustomHeaders    map[string]string
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area config
/area outputs

**What this PR does / why we need it**:

Multiple improvements of http outputs handling.

Addressing the following areas:

1. There is no limit on the number of outgoing http requests, which is combined with with the lack of http client reuse creates  thousands of connections to the host (the http client reuse is addresses in this previous PR https://github.com/falcosecurity/falcosidekick/pull/962). That except in the cases where some auth related http headers are set using the mutex lock that causes the requests to be limited to one at a time competing for the mutex. 
For example the Elasticsearch output is limited to one request at a time when basic auth is used, but will create unlimited number of requests at a time when the custom headers are used to pass basic auth or api key headers: https://github.com/falcosecurity/falcosidekick/blob/master/outputs/elasticsearch.go#L60. Which leads to unpredictable runtime characteristics in terms of connections use etc.
2. FIXME https://github.com/falcosecurity/falcosidekick/blob/a36af89c3ea3ec9ee066e4f05dcaf9d23b11b4c7/outputs/client.go#L11
3. The ```config.go``` defaults settings is prone to mistakes (looking at previous PRs) where the same prefix has to be retyped every time and some defaults are set twice, for example
https://github.com/falcosecurity/falcosidekick/blob/a36af89c3ea3ec9ee066e4f05dcaf9d23b11b4c7/config.go#L400
and 
https://github.com/falcosecurity/falcosidekick/blob/a36af89c3ea3ec9ee066e4f05dcaf9d23b11b4c7/config.go#L409
It also required multiple lines of default definitions when needed to add the new setting per output.


Here is the list of changes addressing the points listed above: 

1. Add ```MaxConcurrentRequests``` configuration per output in order to limit
  the number of requests/connections. Decided to go with 1 as default, because it's already one at time in multiple cases due to the use of the mutex for the auth headers. This is item number 2 listed in the "short term" sections https://github.com/falcosecurity/falcosidekick/issues/963.
I'm using semaphore in order to limit the number of requests. I left one TODO item there, that eventually we want to make http requests and semaphore cancellable to make the http client implementation more robust.

2. Refactor HTTP auth headers handling, addressing this FIXME https://github.com/falcosecurity/falcosidekick/blob/a36af89c3ea3ec9ee066e4f05dcaf9d23b11b4c7/outputs/client.go#L11
This eliminates the unexpected limit on the number of requests in some cases and no limit in another cases with the same output.

3. Extract common configuration for http, refactor NewClient to avoid
  adding one more parameter for ```MaxConcurrentRequests```. 
  Now the outputs cat update requests properties including headers before the request is executed, also allows to use already existing SetBasicAuth method implemented with Go http.Headers.

4. Refactor default configuration definition in order to avoid typos with
  repetitive Output name prefix and avoid repetitive use of defaults. This item is not strictly necessary, but I think makes it easier to manage and add new outputs defaults and avoid errors. Some of the configurations like AWS, GCP a non-output configuration are still left inlined for now, but could be extracted later if needed.

**Example of the throughput improvement for Elasticsearch Output**:

As I mentioned above due to the current use of mutex lock on basic auth header, the requests are executed one after another, one request at a time if the user uses username and password for auth: because of this
https://github.com/falcosecurity/falcosidekick/blob/master/outputs/elasticsearch.go#L60

So current through numbers with Elasticsearch cloud instance are about **4 docs/sec**

Now with addition of ```MaxConcurrentRequests``` configuration, the user can adjust the number of the requests

maxconcurrentrequests | throughput | 
| ------------- |:-------------:|
1 | 4 docs/sec
2 | 8 docs/sec
10 | 40 docs/sec

Now if we combine this PR with with [http client reuse](https://github.com/falcosecurity/falcosidekick/pull/962) we get about **10 doc/sec** with default 1 request at a time

maxconcurrentrequests | throughput | 
| ------------- |:-------------:|
1 | 10 docs/sec
2 | 20 docs/sec
10 | 100 docs/sec

This throughput could improved further with the addition of batching, which I'll have shortly. 

**Which issue(s) this PR fixes**:

Related to # https://github.com/falcosecurity/falcosidekick/issues/963
First steps.

**Special notes for your reviewer**:


