### PR TITLE
fix: don't share same pointer for new reports

### DIFF
--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -54,28 +54,6 @@ const (
 var (
 	defaultNamespace string = "default"
 
-	// default policy report
-	defaultPolicyReport *wgpolicy.PolicyReport = &wgpolicy.PolicyReport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: policyReportName,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "falcosidekick",
-			},
-		},
-		Summary: wgpolicy.PolicyReportSummary{},
-	}
-
-	// default cluster policy report
-	defaultClusterPolicyReport *wgpolicy.ClusterPolicyReport = &wgpolicy.ClusterPolicyReport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterPolicyReportName,
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "falcosidekick",
-			},
-		},
-		Summary: wgpolicy.PolicyReportSummary{},
-	}
-
 	// used resources in the k8saudit ruleset
 	resourceMapping = map[string]resource{
 		"pods":                {"v1", "Pod"},
@@ -95,6 +73,30 @@ var (
 		"rolebindings":        {"rbac.authorization.k8s.io/v1", "RoleBinding"},
 	}
 )
+
+func newPolicyReport() *wgpolicy.PolicyReport {
+	return &wgpolicy.PolicyReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyReportName,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "falcosidekick",
+			},
+		},
+		Summary: wgpolicy.PolicyReportSummary{},
+	}
+}
+
+func newClusterPolicyReport() *wgpolicy.ClusterPolicyReport {
+	return &wgpolicy.ClusterPolicyReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterPolicyReportName,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "falcosidekick",
+			},
+		},
+		Summary: wgpolicy.PolicyReportSummary{},
+	}
+}
 
 func NewPolicyReportClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	clientConfig, err := rest.InClusterConfig()
@@ -201,7 +203,7 @@ func (c *Client) createOrUpdatePolicyReport(result *wgpolicy.PolicyReportResult,
 		}
 	}
 	if policyr.Name == "" {
-		policyr = defaultPolicyReport
+		policyr = newPolicyReport()
 		action = create
 	}
 
@@ -256,7 +258,7 @@ func (c *Client) createOrUpdateClusterPolicyReport(result *wgpolicy.PolicyReport
 		}
 	}
 	if cpolicyr == nil {
-		cpolicyr = defaultClusterPolicyReport
+		cpolicyr = newClusterPolicyReport()
 		action = create
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

currently when a new PolicyReport is created it reuses the modified default PolicyReport and reuses already added results which leads to duplicates in different namespaces.

this change creates new pointers for each new PolicyReport

**Which issue(s) this PR fixes**:

Fixes #970


