### PR TITLE
[Elasticsearch] Add APIKey configuration for Elasticsearch output

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -93,6 +93,7 @@ elasticsearch:
   # suffix: "daily" # date suffix for index rotation : daily (default), monthly, annually, none
   # mutualtls: false # if true, checkcert flag will be ignored (server cert will always be checked)
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
+  # apikey: "" # use this APIKey to authenticate to Elasticsearch if the APIKey is not empty (default: "")
   # username: "" # use this username to authenticate to Elasticsearch if the username is not empty (default: "")
   # password: "" # use this password to authenticate to Elasticsearch if the password is not empty (default: "")
   # flattenfields: false # replace . by _ to avoid mapping conflicts, force to true if createindextemplate==true (default: false)

--- a/docs/outputs/elasticsearch.md
+++ b/docs/outputs/elasticsearch.md
@@ -13,27 +13,28 @@
 
 ## Configuration
 
-|               Setting               |               Env var               |  Default value   |                                                             Description                                                             |
-| ----------------------------------- | ----------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `elasticsearch.hostport`             | `ELASTICSEARCH_HOSTPORT`            |                  | http://{domain or ip}:{port}, if not empty, Elasticsearch output is **enabled**                                                     |
-| `elasticsearch.index`               | `ELASTICSEARCH_INDEX`               | `falco`          | Index                                                                                                                               |
-| `elasticsearch.type`                | `ELASTICSEARCH_TYPE`                | `_doc`           | Index                                                                                                                               |
-| `elasticsearch.suffix`              | `ELASTICSEARCH_SUFFIX`              | `daily`          | Date suffix for index rotation : `daily`, `monthly`, `annually`, `none`                                                             |
-| `elasticsearch.username`            | `ELASTICSEARCH_USERNAME`            |                  | Use this username to authenticate to Elasticsearch                                                                                  |
-| `elasticsearch.password`            | `ELASTICSEARCH_PASSWORD`            |                  | Use this password to authenticate to Elasticsearch                                                                                  |
-| `elasticsearch.flattenfields`       | `ELASTICSEARCH_FLATTENFIELDS`       | `false`          | Replace . by _ to avoid mapping conflicts, force to true if `createindextemplate=true`                                              |
-| `elasticsearch.createindextemplate` | `ELASTICSEARCH_CREATEINDEXTEMPLATE` | `false`          | Create an index template                                                                                                            |
-| `elasticsearch.numberofshards`      | `ELASTICSEARCH_NUMBEROFSHARDS`      | `3`              | Number of shards set by the index template                                                                                          |
-| `elasticsearch.numberofreplicas`    | `ELASTICSEARCH_REPLICAS`            | `3`              | Number of replicas set by the index template                                                                                        |
-| `elasticsearch.customheaders`       | `ELASTICSEARCH_CUSTOMHEADERS`       |                  | Custom headers to add in POST, useful for Authentication                                                                            |
-| `elasticsearch.mutualtls`           | `ELASTICSEARCH_MUTUALTLS`           | `false`          | Authenticate to the output with TLS, if true, checkcert flag will be ignored (server cert will always be checked)                   |
-| `elasticsearch.checkcert`           | `ELASTICSEARCH_CHECKCERT`           | `true`           | Check if ssl certificate of the output is valid                                                                                     |
-| `elasticsearch.minimumpriority`     | `ELASTICSEARCH_MINIMUMPRIORITY`     | `""` (= `debug`) | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
-| `elasticsearch.maxconcurrentrequests`           | `ELASTICSEARCH_MAXCONCURRENTREQUESTS`           | `1`           | Max number of concurrent requests                                                                                     |
-| `elasticsearch.enablecompression`           | `ELASTICSEARCH_ENABLECOMPRESSION`           | `false`           | Enables gzip compression                                                                                     |
-| `elasticsearch.batching.enabled`           |           | `false`           | Enables batching (utilizing Elasticsearch bulk API)
-| `elasticsearch.batching.batchsize`           |           | `5242880`           | Batch size in bytes, default 5MB
-| `elasticsearch.batching.flushinterval`           |           | `1s`           | Batch flush interval, use valid Go duration string
+|               Setting                 |               Env var                |  Default value   |                                                             Description                                                             |
+| ------------------------------------- | ------------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `elasticsearch.hostport`              | `ELASTICSEARCH_HOSTPORT`             |                  | http://{domain or ip}:{port}, if not empty, Elasticsearch output is **enabled**                                                     |
+| `elasticsearch.index`                 | `ELASTICSEARCH_INDEX`                | `falco`          | Index                                                                                                                               |
+| `elasticsearch.type`                  | `ELASTICSEARCH_TYPE`                 | `_doc`           | Index                                                                                                                               |
+| `elasticsearch.suffix`                | `ELASTICSEARCH_SUFFIX`               | `daily`          | Date suffix for index rotation : `daily`, `monthly`, `annually`, `none`                                                             |
+| `elasticsearch.apikey`                | `ELASTICSEARCH_APIKEY`               |                  | Use this APIKey to authenticate to Elasticsearch                                                                                  |
+| `elasticsearch.username`              | `ELASTICSEARCH_USERNAME`             |                  | Use this username to authenticate to Elasticsearch                                                                                  |
+| `elasticsearch.password`              | `ELASTICSEARCH_PASSWORD`             |                  | Use this password to authenticate to Elasticsearch                                                                                  |
+| `elasticsearch.flattenfields`         | `ELASTICSEARCH_FLATTENFIELDS`        | `false`          | Replace . by _ to avoid mapping conflicts, force to true if `createindextemplate=true`                                              |
+| `elasticsearch.createindextemplate`   | `ELASTICSEARCH_CREATEINDEXTEMPLATE`  | `false`          | Create an index template                                                                                                            |
+| `elasticsearch.numberofshards`        | `ELASTICSEARCH_NUMBEROFSHARDS`       | `3`              | Number of shards set by the index template                                                                                          |
+| `elasticsearch.numberofreplicas`      | `ELASTICSEARCH_REPLICAS`             | `3`              | Number of replicas set by the index template                                                                                        |
+| `elasticsearch.customheaders`         | `ELASTICSEARCH_CUSTOMHEADERS`        |                  | Custom headers to add in POST, useful for Authentication                                                                            |
+| `elasticsearch.mutualtls`             | `ELASTICSEARCH_MUTUALTLS`            | `false`          | Authenticate to the output with TLS, if true, checkcert flag will be ignored (server cert will always be checked)                   |
+| `elasticsearch.checkcert`             | `ELASTICSEARCH_CHECKCERT`            | `true`           | Check if ssl certificate of the output is valid                                                                                     |
+| `elasticsearch.minimumpriority`       | `ELASTICSEARCH_MINIMUMPRIORITY`      | `""` (= `debug`) | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
+| `elasticsearch.maxconcurrentrequests` | `ELASTICSEARCH_MAXCONCURRENTREQUESTS`| `1`              | Max number of concurrent requests                                                                                                   |
+| `elasticsearch.enablecompression`     | `ELASTICSEARCH_ENABLECOMPRESSION`    | `false`          | Enables gzip compression                                                                                                            |
+| `elasticsearch.batching.enabled`      |                                      | `false`          | Enables batching (utilizing Elasticsearch bulk API)                                                                                 |
+| `elasticsearch.batching.batchsize`    |                                      | `5242880`        | Batch size in bytes, default 5MB                                                                                                    |
+| `elasticsearch.batching.flushinterval`|                                      | `1s`             | Batch flush interval, use valid Go duration string                                                                                  |
 
 > [!NOTE]
 The Env var values override the settings from yaml file.

--- a/outputs/elasticsearch.go
+++ b/outputs/elasticsearch.go
@@ -105,6 +105,10 @@ func (c *Client) elasticsearchPost(index string, payload []byte, falcoPayloads .
 	c.EndpointURL = endpointURL
 
 	reqOpt := func(req *http.Request) {
+		if c.Config.Elasticsearch.ApiKey != "" {
+			req.Header.Set("Authorization", "APIKey "+c.Config.Elasticsearch.ApiKey)
+		}
+
 		if c.Config.Elasticsearch.Username != "" && c.Config.Elasticsearch.Password != "" {
 			req.SetBasicAuth(c.Config.Elasticsearch.Username, c.Config.Elasticsearch.Password)
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -281,6 +281,7 @@ type ElasticsearchOutputConfig struct {
 	Suffix              string
 	Username            string
 	Password            string
+	ApiKey              string
 	FlattenFields       bool
 	CreateIndexTemplate bool
 	NumberOfShards      int


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

Adds ```APIKey``` configuration for Elasticsearch output

```APIKey``` is a preferred way to authenticated with Elasticsearch, since users can limit it's permissions, assign the expiration, revoke, etc.
<img width="901" alt="Screenshot 2024-08-29 at 1 45 25 PM" src="https://github.com/user-attachments/assets/5bd06e00-9db7-4eb2-ad06-9c16955796a9">

Currently user can configure it with the ```customHeaders```, for example:
```
customHeaders:
    Authorization: "APIKey U1Nfd041RUJKMGlDdzFGeld0anE6aHR2Z0kwbmNUcDZITxxxxxxxxxxxx=="
```

Exposing ```APIKey``` through a dedicated configuration option would hopefully encourage and make easier for users to use APIKey instead of basic auth.

**Special notes for your reviewer**:
Good convenience configuration option

