### PR TITLE
Support multi-architecture(arm64) build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 SHELL=/bin/bash -o pipefail
 
 .DEFAULT_GOAL:=help
-
 GOPATH  := $(shell go env GOPATH)
 GOARCH  := $(shell go env GOARCH)
 GOOS    := $(shell go env GOOS)
@@ -55,15 +54,15 @@ IMAGE_TAG := falcosecurity/falcosidekick:latest
 .PHONY: falcosidekick
 falcosidekick:
 	$(GO) mod download
-	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -gcflags all=-trimpath=/src -asmflags all=-trimpath=/src -a -installsuffix cgo -o $@ .
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -trimpath -ldflags "$(LDFLAGS)" -gcflags all=-trimpath=/src -asmflags all=-trimpath=/src -a -installsuffix cgo -o $@ .
 
-.PHONY: falcosidekick-linux-amd64
-falcosidekick-linux-amd64:
+.PHONY: falcosidekick-linux
+falcosidekick-linux:
 	$(GO) mod download
-	GOOS=linux GOARCH=amd64 $(GO) build -gcflags all=-trimpath=/src -asmflags all=-trimpath=/src -a -installsuffix cgo -o falcosidekick .
+	GOOS=linux GOARCH=$(GOARCH) $(GO) build -ldflags "$(LDFLAGS)" -gcflags all=-trimpath=/src -asmflags all=-trimpath=/src -a -installsuffix cgo -o falcosidekick .
 
 .PHONY: build-image
-build-image: falcosidekick-linux-amd64
+build-image: falcosidekick-linux
 	$(DOCKER) build -t $(IMAGE_TAG) .
 
 .PHONY: push-image


### PR DESCRIPTION
/kind feature
/area build

This PR uses GOARCH environment variable in Makefile also in the falcosidekick container image binary build. It supports builds on arm64 architecture in addition to the amd64.
In addition it add build flags to the container image as well.
Example:

```bash
docker run --rm  docker.io/falcosecurity/falcosidekick:latest --version
GitVersion:    2.29.0-71-g0f39f47-dirty
GitCommit:     0f39f47e11721722a0993690ad472887e17085a7
GitTreeState:  dirty
BuildDate:     '2024-10-15T07:59:36Z'
GoVersion:     go1.23.2
Compiler:      gc
Platform:      linux/arm64
```
