### PR TITLE
fix missing extra fields when the key doesn't contain a dot and flatt…

### DIFF
--- a/outputs/elasticsearch.go
+++ b/outputs/elasticsearch.go
@@ -285,8 +285,10 @@ func (c *Client) buildESPayload(falcopayload types.FalcoPayload) eSPayload {
 
 	if c.Config.Elasticsearch.FlattenFields || c.Config.Elasticsearch.CreateIndexTemplate {
 		for i, j := range payload.OutputFields {
-			payload.OutputFields[strings.ReplaceAll(i, ".", "_")] = j
-			delete(payload.OutputFields, i)
+			if strings.Contains(i, ".") {
+				payload.OutputFields[strings.ReplaceAll(i, ".", "_")] = j
+				delete(payload.OutputFields, i)
+			}
 		}
 	}
 	return payload


### PR DESCRIPTION
…enfields=true

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

If  `elasticsearch.flattenfields == true`, because of a missing check, the output_fields with a key without dot are deleted. 

**Which issue(s) this PR fixes**:

#1033 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


