### PR TITLE
[feature] add falco as source for datadog events

### DIFF
--- a/outputs/datadog.go
+++ b/outputs/datadog.go
@@ -31,7 +31,7 @@ func newDatadogPayload(falcopayload types.FalcoPayload) datadogPayload {
 		tags = append(tags, fmt.Sprintf("%v:%v", i, falcopayload.OutputFields[i]))
 
 	}
-	tags = append(tags, "source:"+falcopayload.Source)
+	tags = append(tags, "source:"+falcopayload.Source, "source:falco")
 	if falcopayload.Hostname != "" {
 		tags = append(tags, Hostname+":"+falcopayload.Hostname)
 	}

--- a/outputs/datadog_test.go
+++ b/outputs/datadog_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewDatadogPayload(t *testing.T) {
-	expectedOutput := `{"title":"Test rule","text":"This is a test from falcosidekick","alert_type":"info","source_type_name":"falco","tags":["proc.name:falcosidekick", "source:syscalls", "hostname:test-host", "example", "test"]}`
+	expectedOutput := `{"title":"Test rule","text":"This is a test from falcosidekick","alert_type":"info","source_type_name":"falco","tags":["proc.name:falcosidekick", "source:syscalls", "source:falco", "hostname:test-host", "example", "test"]}`
 	var f types.FalcoPayload
 	json.Unmarshal([]byte(falcoTestInput), &f)
 	s, _ := json.Marshal(newDatadogPayload(f))


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

> /area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a "falco" source tag to events sent to Datadog. Currently, these events are only tagged according to the Falco event source, and the Datadog default "my apps"  tag, which makes targeting all falco events in datadog quite cumbersome. With an additional "falco" tag, it is now easier to filter falco events.

Before: 
![image](https://github.com/user-attachments/assets/b4f0037d-87d7-4238-a422-9b54dffec4b0)

After:
![image](https://github.com/user-attachments/assets/f2d0e5fa-0b54-4ad2-b026-34e7b058577e)


**Which issue(s) this PR fixes**:

Fixes #1017

**Special notes for your reviewer**:


