### PR TITLE
remove the log line for OTLP Metrics (too noisy)

### DIFF
--- a/outputs/otlpmetrics/otlpmetrics.go
+++ b/outputs/otlpmetrics/otlpmetrics.go
@@ -3,6 +3,10 @@ package otlpmetrics
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -11,9 +15,6 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.23.1"
-	"log"
-	"os"
-	"strings"
 )
 
 const (
@@ -246,5 +247,4 @@ func (c *counterInstrument) Inc() {
 	}
 
 	ruleCounter.Add(context.Background(), 1, metric.WithAttributes(c.attributes...))
-	log.Println("[INFO]  : OTLP Metrics - OK")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

remove noisy log lines from OTLP Metrics (even when not set)

```
2024/12/03 19:59:27 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 19:59:27 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 19:59:27 [INFO]  : OTLP Metrics - OK                                                                                                                                                                                                                                               
2024/12/03 19:59:27 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 20:00:39 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 20:00:39 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 20:00:39 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 20:00:39 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 20:01:01 [INFO]  : OTLP Metrics - OK                                                                                                                                                                    
2024/12/03 20:01:01 [INFO]  : OTLP Metrics - OK    
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


