### PR TITLE
:wrench: Add NS and pod by default in loki output

### DIFF
--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -34,11 +34,11 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 	s["priority"] = falcopayload.Priority.String()
 
 	if k8sNs, ok := falcopayload.OutputFields["k8s.ns.name"].(string); ok {
-        s["k8s_ns_name"] = k8sNs
-    }
-    if k8sPod, ok := falcopayload.OutputFields["k8s.pod.name"].(string); ok {
-        s["k8s_pod_name"] = k8sPod
-    }
+		s["k8s_ns_name"] = k8sNs
+	}
+	if k8sPod, ok := falcopayload.OutputFields["k8s.pod.name"].(string); ok {
+		s["k8s_pod_name"] = k8sPod
+	}
 
 	for i, j := range falcopayload.OutputFields {
 		switch v := j.(type) {

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -33,6 +33,13 @@ func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration
 	s["source"] = falcopayload.Source
 	s["priority"] = falcopayload.Priority.String()
 
+	if k8sNs, ok := falcopayload.OutputFields["k8s.ns.name"].(string); ok {
+        s["k8s_ns_name"] = k8sNs
+    }
+    if k8sPod, ok := falcopayload.OutputFields["k8s.pod.name"].(string); ok {
+        s["k8s_pod_name"] = k8sPod
+    }
+
 	for i, j := range falcopayload.OutputFields {
 		switch v := j.(type) {
 		case string:

--- a/outputs/loki.go
+++ b/outputs/loki.go
@@ -28,7 +28,7 @@ type lokiValue = []string
 const LokiContentType = "application/json"
 
 func newLokiPayload(falcopayload types.FalcoPayload, config *types.Configuration) lokiPayload {
-	s := make(map[string]string, 3+len(falcopayload.OutputFields)+len(config.Loki.ExtraLabelsList)+len(falcopayload.Tags))
+	s := make(map[string]string)
 	s["rule"] = falcopayload.Rule
 	s["source"] = falcopayload.Source
 	s["priority"] = falcopayload.Priority.String()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
/kind design

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR puts the namespace and pod name as default fields in the loki output if they exist.
This is really useful to have a good setup at start and do not go into the `extraLabels` config as they are important keys to get.
Moreover, some of these labels are used by default by the [dashboard](https://github.com/falcosecurity/charts/blob/b4e6411fca3caa7771e2bec1490b2fdc24ce2b71/charts/falcosidekick/dashboards/falcosidekick-loki-dashboard.json#L286), so it would be perfect if all the deployment (loki + dashboard) is working without extra configuration needed

