### PR TITLE
feat: add azure sentinel output

### DIFF
--- a/config.go
+++ b/config.go
@@ -262,6 +262,15 @@ var httpOutputDefaults = map[string]map[string]any{
 		"Username":         "",
 		"Password":         "",
 	},
+	"AzureSentinel": {
+        "WorkspaceID":         "",
+        "SharedKey":           "",
+        "TableName":           "FalcoEvents",
+        "MinimumPriority":     "",
+        "MutualTLS":           false,
+        "CheckCert":           true,
+        "MaxConcurrentRequests": 1,
+    },
 }
 
 // Other output defaults that do not need commonHttpOutputDefaults

--- a/handlers.go
+++ b/handlers.go
@@ -552,4 +552,8 @@ func forwardEvent(falcopayload types.FalcoPayload) {
 	if config.Talon.Address != "" && (falcopayload.Priority >= types.Priority(config.Talon.MinimumPriority) || falcopayload.Rule == testRule) {
 		go talonClient.TalonPost(falcopayload)
 	}
+
+	if config.AzureSentinel.WorkspaceID != "" && (falcopayload.Priority >= types.Priority(config.AzureSentinel.MinimumPriority) || falcopayload.Rule == testRule) {
+		go azureSentinelClient.AzureSentinelPost(falcopayload)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ var (
 	otlpTracesClient    *outputs.Client
 	otlpLogsClient      *outputs.Client
 	talonClient         *outputs.Client
+	azureSentinelClient *outputs.Client
 
 	statsdClient, dogstatsdClient *statsd.Client
 	config                        *types.Configuration
@@ -865,6 +866,18 @@ func init() {
 			config.Talon.Address = ""
 		} else {
 			outputs.EnabledOutputs = append(outputs.EnabledOutputs, "Talon")
+		}
+	}
+
+	if config.AzureSentinel.WorkspaceID != "" && config.AzureSentinel.SharedKey != "" {
+		var err error
+		url := fmt.Sprintf("https://%s.ods.opinsights.azure.com/api/logs?api-version=2016-04-01", config.AzureSentinel.WorkspaceID)
+		azureSentinelClient, err = outputs.NewClient("AzureSentinel", url, config.AzureSentinel.CommonConfig, *initClientArgs)
+		if err != nil {
+			config.AzureSentinel.WorkspaceID = ""
+			config.AzureSentinel.SharedKey = ""
+		} else {
+			outputs.EnabledOutputs = append(outputs.EnabledOutputs, "AzureSentinel")
 		}
 	}
 

--- a/outputs/azure_sentinel.go
+++ b/outputs/azure_sentinel.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package outputs
+
+import (
+    "bytes"
+    "crypto/hmac"
+    "crypto/sha256"
+    "crypto/tls"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "time"
+
+    "go.opentelemetry.io/otel/attribute"
+
+    "github.com/falcosecurity/falcosidekick/internal/pkg/utils"
+    "github.com/falcosecurity/falcosidekick/types"
+)
+
+// getClientTransport returns a proper http transport based on the TLS configuration
+func getClientTransport(checkCert bool) *http.Transport {
+    return &http.Transport{
+        TLSClientConfig: &tls.Config{
+            InsecureSkipVerify: !checkCert,
+        },
+    }
+}
+
+type azureSentinelPayload struct {
+    Rule     string                 `json:"Rule"`
+    Priority string                 `json:"Priority"`
+    Source   string                 `json:"Source"`
+    Output   string                 `json:"Output"`
+    Time     string                 `json:"Time"`
+    Hostname string                 `json:"Hostname,omitempty"`
+    Fields   map[string]interface{} `json:"-"`
+}
+
+func newAzureSentinelPayload(falcopayload types.FalcoPayload) []map[string]interface{} {
+    // Create the base payload
+    row := map[string]interface{}{
+        "Rule":     falcopayload.Rule,
+        "Priority": falcopayload.Priority.String(),
+        "Source":   falcopayload.Source,
+        "Output":   falcopayload.Output,
+        "Time":     falcopayload.Time.Format(time.RFC3339),
+    }
+    
+    // Add hostname if available
+    if falcopayload.Hostname != "" {
+        row["Hostname"] = falcopayload.Hostname
+    }
+
+    // Add all output fields to the payload
+    if len(falcopayload.OutputFields) > 0 {
+        for k, v := range falcopayload.OutputFields {
+            row[k] = v
+        }
+    }
+
+    return []map[string]interface{}{row}
+}
+
+// AzureSentinelPost sends event to Azure Sentinel
+func (c *Client) AzureSentinelPost(falcopayload types.FalcoPayload) {
+    c.Stats.AzureSentinel.Add(Total, 1)
+
+    workspaceID := c.Config.AzureSentinel.WorkspaceID
+    sharedKey := c.Config.AzureSentinel.SharedKey
+    tableName := c.Config.AzureSentinel.TableName
+
+    payload := newAzureSentinelPayload(falcopayload)
+    body, err := json.Marshal(payload)
+    if err != nil {
+        go c.CountMetric(Outputs, 1, []string{"output:azuresentinel", "status:error"})
+        c.Stats.AzureSentinel.Add(Error, 1)
+        c.PromStats.Outputs.With(map[string]string{"destination": "azure_sentinel", "status": Error}).Inc()
+        c.OTLPMetrics.Outputs.With(attribute.String("destination", "azure_sentinel"),
+            attribute.String("status", Error)).Inc()
+        utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("Error marshaling payload: %v", err))
+        return
+    }
+
+    // Create API signature for Azure Sentinel
+    date := time.Now().UTC().Format(http.TimeFormat)
+    contentLength := len(body)
+    stringToSign := fmt.Sprintf("POST\n%d\napplication/json\nx-ms-date:%s\n/api/logs", contentLength, date)
+
+    keyBytes, _ := base64.StdEncoding.DecodeString(sharedKey)
+    mac := hmac.New(sha256.New, keyBytes)
+    mac.Write([]byte(stringToSign))
+    signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+    authHeader := fmt.Sprintf("SharedKey %s:%s", workspaceID, signature)
+
+    // Create and send request
+    url := fmt.Sprintf("https://%s.ods.opinsights.azure.com/api/logs?api-version=2016-04-01", workspaceID)
+    req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+    if err != nil {
+        go c.CountMetric(Outputs, 1, []string{"output:azuresentinel", "status:error"})
+        c.Stats.AzureSentinel.Add(Error, 1)
+        c.PromStats.Outputs.With(map[string]string{"destination": "azure_sentinel", "status": Error}).Inc()
+        c.OTLPMetrics.Outputs.With(attribute.String("destination", "azure_sentinel"),
+            attribute.String("status", Error)).Inc()
+        utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("Error creating request: %v", err))
+        return
+    }
+
+    req.Header.Add("Content-Type", "application/json")
+    req.Header.Add("Log-Type", tableName)
+    req.Header.Add("x-ms-date", date)
+    req.Header.Add("Authorization", authHeader)
+
+    httpClient := http.Client{
+        Transport: getClientTransport(c.Config.AzureSentinel.CheckCert),
+        Timeout:   time.Duration(c.Config.AzureSentinel.MaxConcurrentRequests) * time.Second,
+    }
+    
+    resp, err := httpClient.Do(req)
+    if (err != nil) {
+        go c.CountMetric(Outputs, 1, []string{"output:azuresentinel", "status:error"})
+        c.Stats.AzureSentinel.Add(Error, 1)
+        c.PromStats.Outputs.With(map[string]string{"destination": "azure_sentinel", "status": Error}).Inc()
+        c.OTLPMetrics.Outputs.With(attribute.String("destination", "azure_sentinel"),
+            attribute.String("status", Error)).Inc()
+        utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("Error sending event: %v", err))
+        return
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+        go c.CountMetric(Outputs, 1, []string{"output:azuresentinel", "status:error"})
+        c.Stats.AzureSentinel.Add(Error, 1)
+        c.PromStats.Outputs.With(map[string]string{"destination": "azure_sentinel", "status": Error}).Inc()
+        c.OTLPMetrics.Outputs.With(attribute.String("destination", "azure_sentinel"),
+            attribute.String("status", Error)).Inc()
+        utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("HTTP response error (%d): %s", resp.StatusCode, resp.Status))
+        return
+    }
+
+    go c.CountMetric(Outputs, 1, []string{"output:azuresentinel", "status:ok"})
+    c.Stats.AzureSentinel.Add(OK, 1)
+    c.PromStats.Outputs.With(map[string]string{"destination": "azure_sentinel", "status": OK}).Inc()
+    c.OTLPMetrics.Outputs.With(attribute.String("destination", "azure_sentinel"),
+        attribute.String("status", OK)).Inc()
+}

--- a/outputs/azuresentinel_test.go
+++ b/outputs/azuresentinel_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package outputs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/falcosecurity/falcosidekick/types"
+)
+
+func TestNewAzureSentinelPayload(t *testing.T) {
+	expected := map[string]interface{}{
+		"Rule":     "Test rule",
+		"Priority": "Debug",
+		"Source":   "syscalls",
+		"Output":   "This is a test from falcosidekick",
+		"Time":     "2001-01-01T01:10:00Z",
+		"Hostname": "test-host",
+		"proc.name": "falcosidekick",
+		// JSON unmarshaling converts numbers to float64
+		"proc.tty": float64(1234),
+	}
+
+	var f types.FalcoPayload
+	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+
+	payload := newAzureSentinelPayload(f)
+	require.Equal(t, 1, len(payload))
+	
+	// Compare expected map keys and values
+	for key, expectedVal := range expected {
+		val, exists := payload[0][key]
+		require.True(t, exists, "Expected key %s does not exist in payload", key)
+		require.Equal(t, expectedVal, val, "Value mismatch for key %s", key)
+	}
+}

--- a/stats.go
+++ b/stats.go
@@ -55,6 +55,7 @@ func getInitStats() *types.Statistics {
 		Webhook:           getOutputNewMap("webhook"),
 		CloudEvents:       getOutputNewMap("cloudevents"),
 		AzureEventHub:     getOutputNewMap("azureeventhub"),
+		AzureSentinel:     getOutputNewMap("azuresentinel"),
 		GCPPubSub:         getOutputNewMap("gcppubsub"),
 		GCPStorage:        getOutputNewMap("gcpstorage"),
 		GCPCloudFunctions: getOutputNewMap("gcpcloudfunctions"),

--- a/types/types.go
+++ b/types/types.go
@@ -120,6 +120,7 @@ type Configuration struct {
 	Dynatrace          DynatraceOutputConfig
 	OTLP               OTLPOutputConfig
 	Talon              TalonOutputConfig
+	AzureSentinel AzureSentinelOutputConfig `mapstructure:"AzureSentinel"`
 }
 
 // InitClientArgs represent a client parameters for initialization
@@ -837,6 +838,15 @@ type TalonOutputConfig struct {
 	MinimumPriority string
 }
 
+// AzureSentinelOutputConfig represents parameters for Azure Sentinel
+type AzureSentinelOutputConfig struct {
+    CommonConfig    `mapstructure:",squash"`
+    WorkspaceID     string
+    SharedKey       string
+    TableName       string
+    MinimumPriority string
+}
+
 // Statistics is a struct to store stastics
 type Statistics struct {
 	Requests          *expvar.Map
@@ -872,6 +882,7 @@ type Statistics struct {
 	Webhook           *expvar.Map
 	Webex             *expvar.Map
 	AzureEventHub     *expvar.Map
+	AzureSentinel     *expvar.Map
 	GCPPubSub         *expvar.Map
 	GCPStorage        *expvar.Map
 	GCPCloudFunctions *expvar.Map


### PR DESCRIPTION
feat: add azure sentinel output

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> /kind feature

**Any specific area of the project related to this PR?**

> /area outputs

**What this PR does / why we need it**:

This PR introduces support for Azure Sentinel as an output in FalcoSidekick. It enables users to send security events directly to Azure Sentinel, improving integration with Microsoft security services.

**Special notes for your reviewer**:

- The implementation follows the existing output structure in FalcoSidekick.
- Configuration details for the Azure Sentinel output are documented in the README.
- Unit tests have been added to cover the new functionality.
