### PR TITLE
Allow specifying redis username

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -491,6 +491,7 @@ timescaledb:
 
 redis:
   # address: "" # Redis address, if not empty, Redis output is enabled
+  # username: "" # Username to authenticate with Redis (default: "")
   # password: "" # Password to authenticate with Redis (default: "")
   # database: "" # Redis database number (default: 0)
   # storagetype: "" # Redis storage type: hashmap or list (default: "list")
@@ -581,7 +582,7 @@ talon:
 logstash:
   # address: "" # Logstash address, if not empty, Logstash output is enabled
   # port: 5044 # Logstash port number (default: 5044)
-  # tls: false # communicate over tls; requires Logstash version 8+ to work 
+  # tls: false # communicate over tls; requires Logstash version 8+ to work
   # mutualtls: false # or authenticate to the output with TLS; if true, checkcert flag will be ignored (server cert will always be checked) (default: false)
   # checkcert: true # Check if ssl certificate of the output is valid (default: true)
   # certfile: "" # Use this certificate file instead of the client certificate when using mutual TLS (default: "")

--- a/docs/outputs/redis.md
+++ b/docs/outputs/redis.md
@@ -20,6 +20,7 @@
 | `redis.database`        | `REDIS_DATABASE`        | `0`              | Redis database number                                                                                                               |
 | `redis.storagetype`     | `REDIS_STORAGETYPE`     | `list`           | Redis storage type: `hashmap` or `list`                                                                                             |
 | `redis.key`             | `REDIS_KEY`             | `falco`          | Redis storage key name                                                                                                              |
+| `redis.username`        | N/A | | Redis user to authenticate with Redis. By default no username is set. [See ACLs for more information](https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/). |
 | `redis.password`        | `REDIS_PASSWORD`        |                  | Password to authenticate with Redis                                                                                                 |
 | `redis.minimumpriority` | `REDIS_MINIMUMPRIORITY` | `""` (= `debug`) | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
 
@@ -34,6 +35,7 @@ redis:
   # database: "" # Redis database number (default: 0)
   # storagetype: "" # Redis storage type: hashmap or list (default: list)
   # key: "" # Redis storage key name (default: "falco")
+  # username: "" # Username to authenticate with Redis (default: "")
   # password: "" # Password to authenticate with Redis (default: "")
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 ```

--- a/outputs/redis.go
+++ b/outputs/redis.go
@@ -31,6 +31,7 @@ func NewRedisClient(config *types.Configuration, stats *types.Statistics, promSt
 
 	rClient := redis.NewClient(&redis.Options{
 		Addr:     config.Redis.Address,
+		Username: config.Redis.Username,
 		Password: config.Redis.Password,
 		DB:       config.Redis.Database,
 	})

--- a/types/types.go
+++ b/types/types.go
@@ -750,6 +750,7 @@ type TimescaleDBConfig struct {
 // RedisConfig represents config parameters for Redis
 type RedisConfig struct {
 	Address         string
+	Username        string
 	Password        string
 	Database        int
 	StorageType     string


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Any specific area of the project related to this PR?**
/area outputs

**What this PR does / why we need it**:
Some systems administrators prefer to run redis more locked down than the default configuration it ships with.

**Which issue(s) this PR fixes**:

Fixes #1210 

**Special notes for your reviewer**:

### Redis configuration
ACL file
```
user default off
user falcosidekick-user on +@all ~* >testpassword
```

Masterauth file
```
masteruser falcosidekick-user
masterauth testpassword
```

Run redis
```
/usr/bin/redis-server localhost:6379 --aclfile redis-acl.txt --include masterauth.txt
```

### Falcosidekick config
```
listenaddress: 127.0.0.1
listenport: 2801

redis:
  address: "localhost:6379"
  key: "falco"
  username: "falcosidekick-user"
  password: "testpassword"
  minimumpriority: ""
```

Running falcosidekick
```
2025/07/11 21:11:05 [INFO]  : Falcosidekick version: beb4375-dirty
2025/07/11 21:11:05 [INFO]  : Redis - Connected to redis server: PONG
2025/07/11 21:11:05 [INFO]  : Enabled Outputs: [Redis]
2025/07/11 21:11:05 [INFO]  : Falcosidekick is up and listening on :2801
```

