### PR TITLE
fix: Modify AWS output to use recommended chain of configuration providers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,10 +10,10 @@ env:
   - COSIGN_YES=true
 
 snapshot:
-  version_template: 'latest'
+  version_template: "latest"
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 # Prevents parallel builds from stepping on each others toes downloading modules
 before:
@@ -36,11 +36,7 @@ builds:
       - arm64
       - arm
     goarm:
-      - '7'
-    asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
-    gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
+      - "7"
     env:
       - CGO_ENABLED=0
     flags:
@@ -51,6 +47,11 @@ builds:
 
 dockers_v2:
   - dockerfile: Dockerfile
+    platforms:
+      - linux/amd64
+      - linux/arm64
+      - linux/arm/v7
+
     images:
       - "falcosecurity/falcosidekick"
       - "public.ecr.aws/falcosecurity/falcosidekick"

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ ifdef SOURCE_DATE_EPOCH
 else
     BUILD_DATE ?= $(shell date "$(DATE_FMT)")
 endif
-GIT_TREESTATE = "clean"
+GIT_TREESTATE = clean
 DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
 ifeq ($(DIFF), 1)
-    GIT_TREESTATE = "dirty"
+    GIT_TREESTATE = dirty
 endif
 
 PKG=main

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.39.0
 	github.com/aws/aws-sdk-go-v2/config v1.25.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.2
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.4
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.3
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.35.4
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.77.4
@@ -66,7 +65,10 @@ require (
 	sigs.k8s.io/wg-policy-prototypes v0.0.0-20240327135653-0fc2ddc5d3e3
 )
 
-require go.yaml.in/yaml/v2 v2.4.2 // indirect
+require (
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.4 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
+)
 
 require (
 	cel.dev/expr v0.24.0 // indirect


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area outputs

**What this PR does / why we need it**:

This PR modifies the AWS output client configuration to use the [recommended chain of credential providers](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#loading-aws-shared-configuration). This includes support for static access key credentials as before, as well as eg. `AWS_WEB_IDENTITY_TOKEN_FILE`, which is used on EKS when running workloads with IRSA. See supported providers [in the Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials) docs.

**Which issue(s) this PR fixes**:

It is a security best practice to use IAM roles instead of creating static IAM credentials ie. `AWS_ACCESS_KEY_ID ` and `AWS_SECRET_ACCESS_KEY` pairs, which can be leaked and their distribution and rotation presents an unnecessary maintenance burden.

This PR makes the Falco sidekick work with EKS native `AWS_WEB_IDENTITY_TOKEN_FILE` authentication where EKS injects transient IAM credentials for an IAM role automatically.

The change is backwards compatible; specifying `AWS_ACCESS_KEY_ID` as before functions the same with the default configuration provider. 
