### PR TITLE
fix: removing falco_events prom metric to address OOMing

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,11 @@ The daemon exposes a `prometheus` endpoint on URI `/metrics`.
 
 See the [docs](https://github.com/falcosecurity/falcosidekick/blob/master/docs/outputs/prometheus.md) for more info.
 
+> [!WARNING]
+> **Breaking change**: The `prometheus.extralabels` configuration option (and `PROMETHEUS_EXTRALABELS` env var) has been removed. Fields are no longer added as extra labels on Prometheus metrics. If you had dashboards or alerts relying on labels set via `prometheus.extralabels`, you will need to update them accordingly.
+
+For additional context, see [issue #1132](https://github.com/falcosecurity/falcosidekick/issues/1132). For best practices on using Falco metrics, refer to the [Falco metrics documentation](https://falco.org/docs/concepts/metrics/).
+
 ### StatsD / DogStatsD
 
 The daemon is able to push its metrics to a StatsD/DogstatsD server. See

--- a/config.go
+++ b/config.go
@@ -547,8 +547,6 @@ func getConfig() *types.Configuration {
 
 	v.SetDefault("Alertmanager.MinimumPriority", "")
 
-	v.SetDefault("Prometheus.ExtraLabels", "")
-
 	v.SetDefault("Azure.eventHub.Namespace", "")
 	v.SetDefault("Azure.eventHub.Name", "")
 	v.SetDefault("Azure.eventHub.MinimumPriority", "")
@@ -874,10 +872,6 @@ func getConfig() *types.Configuration {
 		if c.Elasticsearch.Batching.FlushInterval <= 0 {
 			c.Elasticsearch.Batching.FlushInterval = types.DefaultFlushInterval
 		}
-	}
-
-	if c.Prometheus.ExtraLabels != "" {
-		c.Prometheus.ExtraLabelsList = strings.Split(strings.ReplaceAll(c.Prometheus.ExtraLabels, " ", ""), ",")
 	}
 
 	if c.OTLP.Metrics.ExtraAttributes != "" {

--- a/config.go
+++ b/config.go
@@ -554,8 +554,6 @@ func getConfig() *types.Configuration {
 
 	v.SetDefault("Alertmanager.MinimumPriority", "")
 
-	v.SetDefault("Prometheus.ExtraLabels", "")
-
 	v.SetDefault("Azure.eventHub.Namespace", "")
 	v.SetDefault("Azure.eventHub.Name", "")
 	v.SetDefault("Azure.eventHub.MinimumPriority", "")
@@ -890,10 +888,6 @@ func getConfig() *types.Configuration {
 		if c.Elasticsearch.Batching.FlushInterval <= 0 {
 			c.Elasticsearch.Batching.FlushInterval = types.DefaultFlushInterval
 		}
-	}
-
-	if c.Prometheus.ExtraLabels != "" {
-		c.Prometheus.ExtraLabelsList = strings.Split(strings.ReplaceAll(c.Prometheus.ExtraLabels, " ", ""), ",")
 	}
 
 	if c.OTLP.Metrics.ExtraAttributes != "" {

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -232,7 +232,6 @@ smtp:
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 
 prometheus:
-  # extralabels: "" # comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields
 
 statsd:
   forwarder: "" # The address for the StatsD forwarder, in the form "host:port", if not empty StatsD is enabled

--- a/docs/outputs/prometheus.md
+++ b/docs/outputs/prometheus.md
@@ -14,9 +14,7 @@
 
 ## Configuration
 
-| Setting                  | Env var                  | Default value | Description                                                                                                    |
-| ------------------------ | ------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------- |
-| `prometheus.extralabels` | `PROMETHEUS_EXTRALABELS` |               | Comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields |
+This output has no specific configuration settings.
 
 > [!NOTE]
 The Env var values override the settings from yaml file.
@@ -25,7 +23,6 @@ The Env var values override the settings from yaml file.
 
 ```yaml
 prometheus:
-  # extralabels: "" # comma separated list of fields to use as labels additionally to rule, source, priority, tags and custom_fields
 ```
 
 ## Additional info

--- a/handlers.go
+++ b/handlers.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -129,18 +128,6 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	falcopayload.UUID = uuid.New().String()
 
-	var kn, kp string
-	for i, j := range falcopayload.OutputFields {
-		if j != nil {
-			if i == "k8s.ns.name" {
-				kn = j.(string)
-			}
-			if i == "k8s.pod.name" {
-				kp = j.(string)
-			}
-		}
-	}
-
 	var templatedFields string
 	if len(config.Templatedfields) > 0 {
 		if falcopayload.OutputFields == nil {
@@ -167,46 +154,6 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	nullClient.CountMetric("falco.accepted", 1, []string{"priority:" + falcopayload.Priority.String()})
 	stats.Falco.Add(strings.ToLower(falcopayload.Priority.String()), 1)
-	promLabels := map[string]string{
-		"rule":         falcopayload.Rule,
-		"priority_raw": strings.ToLower(falcopayload.Priority.String()),
-		"priority":     strconv.Itoa(int(falcopayload.Priority)),
-		"source":       falcopayload.Source,
-		"k8s_ns_name":  kn,
-		"k8s_pod_name": kp,
-	}
-	if falcopayload.Hostname != "" {
-		promLabels["hostname"] = falcopayload.Hostname
-	} else {
-		promLabels["hostname"] = "unknown"
-	}
-
-	for key, value := range config.Customfields {
-		sanitizedKey := strings.ReplaceAll(key, ".", "_")
-		if regPromLabels.MatchString(sanitizedKey) {
-			promLabels[sanitizedKey] = value
-		}
-	}
-	for key := range config.Templatedfields {
-		sanitizedKey := strings.ReplaceAll(key, ".", "_")
-		if regPromLabels.MatchString(sanitizedKey) {
-			promLabels[sanitizedKey] = fmt.Sprintf("%v", falcopayload.OutputFields[key])
-		}
-	}
-	for _, i := range config.Prometheus.ExtraLabelsList {
-		promLabels[strings.ReplaceAll(i, ".", "_")] = ""
-		for key, value := range falcopayload.OutputFields {
-			if key == i && regPromLabels.MatchString(strings.ReplaceAll(key, ".", "_")) {
-				switch value.(type) {
-				case string:
-					promLabels[strings.ReplaceAll(key, ".", "_")] = fmt.Sprintf("%v", value)
-				default:
-					continue
-				}
-			}
-		}
-	}
-	promStats.Falco.With(promLabels).Inc()
 
 	// Falco OTLP metric
 	hostname := falcopayload.Hostname
@@ -222,9 +169,8 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	}
 
 	for key, value := range config.Customfields {
-		sanitizedKey := strings.ReplaceAll(key, ".", "_")
-		if regOTLPMetricsAttributes.MatchString(sanitizedKey) {
-			attrs = append(attrs, attribute.String(sanitizedKey, value))
+		if regOTLPMetricsAttributes.MatchString(key) {
+			attrs = append(attrs, attribute.String(key, value))
 		}
 	}
 	for _, attr := range config.OTLP.Metrics.ExtraAttributesList {
@@ -467,7 +413,7 @@ func forwardEvent(falcopayload types.FalcoPayload) {
 		go tektonClient.TektonPost(falcopayload)
 	}
 
-	if config.Rabbitmq.URL != "" && config.Rabbitmq.Queue != "" && (falcopayload.Priority >= types.Priority(config.Rabbitmq.MinimumPriority) || falcopayload.Rule == testRule) {
+	if config.Rabbitmq.URL != "" && config.Rabbitmq.Queue != "" && (falcopayload.Priority >= types.Priority(config.Openfaas.MinimumPriority) || falcopayload.Rule == testRule) {
 		go rabbitmqClient.Publish(falcopayload)
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -129,18 +128,6 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	falcopayload.UUID = uuid.New().String()
 
-	var kn, kp string
-	for i, j := range falcopayload.OutputFields {
-		if j != nil {
-			if i == "k8s.ns.name" {
-				kn = j.(string)
-			}
-			if i == "k8s.pod.name" {
-				kp = j.(string)
-			}
-		}
-	}
-
 	var templatedFields string
 	if len(config.Templatedfields) > 0 {
 		if falcopayload.OutputFields == nil {
@@ -167,46 +154,6 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	nullClient.CountMetric("falco.accepted", 1, []string{"priority:" + falcopayload.Priority.String()})
 	stats.Falco.Add(strings.ToLower(falcopayload.Priority.String()), 1)
-	promLabels := map[string]string{
-		"rule":         falcopayload.Rule,
-		"priority_raw": strings.ToLower(falcopayload.Priority.String()),
-		"priority":     strconv.Itoa(int(falcopayload.Priority)),
-		"source":       falcopayload.Source,
-		"k8s_ns_name":  kn,
-		"k8s_pod_name": kp,
-	}
-	if falcopayload.Hostname != "" {
-		promLabels["hostname"] = falcopayload.Hostname
-	} else {
-		promLabels["hostname"] = "unknown"
-	}
-
-	for key, value := range config.Customfields {
-		sanitizedKey := strings.ReplaceAll(key, ".", "_")
-		if regPromLabels.MatchString(sanitizedKey) {
-			promLabels[sanitizedKey] = value
-		}
-	}
-	for key := range config.Templatedfields {
-		sanitizedKey := strings.ReplaceAll(key, ".", "_")
-		if regPromLabels.MatchString(sanitizedKey) {
-			promLabels[sanitizedKey] = fmt.Sprintf("%v", falcopayload.OutputFields[key])
-		}
-	}
-	for _, i := range config.Prometheus.ExtraLabelsList {
-		promLabels[strings.ReplaceAll(i, ".", "_")] = ""
-		for key, value := range falcopayload.OutputFields {
-			if key == i && regPromLabels.MatchString(strings.ReplaceAll(key, ".", "_")) {
-				switch value.(type) {
-				case string:
-					promLabels[strings.ReplaceAll(key, ".", "_")] = fmt.Sprintf("%v", value)
-				default:
-					continue
-				}
-			}
-		}
-	}
-	promStats.Falco.With(promLabels).Inc()
 
 	// Falco OTLP metric
 	hostname := falcopayload.Hostname
@@ -222,9 +169,8 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	}
 
 	for key, value := range config.Customfields {
-		sanitizedKey := strings.ReplaceAll(key, ".", "_")
-		if regOTLPMetricsAttributes.MatchString(sanitizedKey) {
-			attrs = append(attrs, attribute.String(sanitizedKey, value))
+		if regOTLPMetricsAttributes.MatchString(key) {
+			attrs = append(attrs, attribute.String(key, value))
 		}
 	}
 	for _, attr := range config.OTLP.Metrics.ExtraAttributesList {

--- a/main.go
+++ b/main.go
@@ -92,7 +92,6 @@ var (
 	otlpMetrics                   *otlpmetrics.OTLPMetrics
 	initClientArgs                *types.InitClientArgs
 
-	regPromLabels            *regexp.Regexp
 	regOTLPMetricsAttributes *regexp.Regexp
 	regOutputFormat          *regexp.Regexp
 	shutDownFuncs            []func()
@@ -109,7 +108,6 @@ func init() {
 		return
 	}
 
-	regPromLabels, _ = regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
 	// TODO: replace the following regex if something more appropriate is found
 	regOTLPMetricsAttributes = regexp.MustCompile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
 	regOutputFormat, _ = regexp.Compile(`(?i)[0-9:]+\.[0-9]+: (Debug|Informational|Notice|Warning|Error|Critical|Alert|Emergency) .*`)

--- a/stats_prometheus.go
+++ b/stats_prometheus.go
@@ -3,22 +3,15 @@
 package main
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-
+	"github.com/falcosecurity/falcosidekick/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"
-	"github.com/falcosecurity/falcosidekick/types"
 )
 
 const metricPrefix string = "falcosecurity_falcosidekick_"
 
 func getInitPromStats(config *types.Configuration) *types.PromStatistics {
 	promStats = &types.PromStatistics{
-		Falco:   getFalcoNewCounterVec(config),
 		Inputs:  getInputNewCounterVec(),
 		Outputs: getOutputNewCounterVec(),
 	}
@@ -40,45 +33,5 @@ func getOutputNewCounterVec() *prometheus.CounterVec {
 			Name: metricPrefix + "outputs_total",
 		},
 		[]string{"destination", "status"},
-	)
-}
-
-func getFalcoNewCounterVec(config *types.Configuration) *prometheus.CounterVec {
-	regPromLabels, _ := regexp.Compile("^[a-zA-Z_:][a-zA-Z0-9_:]*$")
-	labelnames := []string{
-		"hostname",
-		"rule",
-		"priority",
-		"priority_raw",
-		"source",
-		"k8s_ns_name",
-		"k8s_pod_name",
-	}
-	for i := range config.Customfields {
-		if !regPromLabels.MatchString(strings.ReplaceAll(i, ".", "_")) {
-			utils.Log(utils.ErrorLvl, "Prometheus", fmt.Sprintf("Custom field '%v' is not a valid prometheus label", i))
-			continue
-		}
-		labelnames = append(labelnames, strings.ReplaceAll(i, ".", "_"))
-	}
-	for i := range config.Templatedfields {
-		if !regPromLabels.MatchString(strings.ReplaceAll(i, ".", "_")) {
-			utils.Log(utils.ErrorLvl, "Prometheus", fmt.Sprintf("Templated field '%v' is not a valid prometheus label", i))
-			continue
-		}
-		labelnames = append(labelnames, strings.ReplaceAll(i, ".", "_"))
-	}
-	for _, i := range config.Prometheus.ExtraLabelsList {
-		if !regPromLabels.MatchString(strings.ReplaceAll(i, ".", "_")) {
-			utils.Log(utils.ErrorLvl, "Prometheus", fmt.Sprintf("Extra field '%v' is not a valid prometheus label", i))
-			continue
-		}
-		labelnames = append(labelnames, strings.ReplaceAll(i, ".", "_"))
-	}
-	return promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: metricPrefix + "falco_events_total",
-		},
-		labelnames,
 	)
 }

--- a/stats_prometheus_test.go
+++ b/stats_prometheus_test.go
@@ -1,32 +1,3 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 package main
-
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/falcosecurity/falcosidekick/types"
-)
-
-func TestFalcoNewCounterVec(t *testing.T) {
-	c := &types.Configuration{
-		Customfields: make(map[string]string),
-	}
-	c.Customfields["test"] = "foo"
-	c.Customfields["should*fail"] = "bar"
-	c.Customfields["k8s.cluster.name"] = "my-cluster"
-
-	cv := getFalcoNewCounterVec(c)
-	shouldbe := []string{"hostname", "rule", "priority", "priority_raw", "source", "k8s_ns_name", "k8s_pod_name", "k8s_cluster_name", "test"}
-	mm, err := cv.GetMetricWithLabelValues(shouldbe...)
-	if err != nil {
-		t.Errorf("Error getting Metrics from promauto")
-	}
-	metricDescString := mm.Desc().String()
-	require.Contains(t, metricDescString, "k8s_cluster_name")
-	require.Contains(t, metricDescString, "test")
-	require.NotContains(t, metricDescString, "should*fail")
-	require.NotContains(t, metricDescString, "k8s.cluster.name")
-}

--- a/stats_prometheus_test.go
+++ b/stats_prometheus_test.go
@@ -1,3 +1,0 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
-package main

--- a/types/types.go
+++ b/types/types.go
@@ -942,7 +942,6 @@ type Statistics struct {
 
 // PromStatistics is a struct to store prometheus metrics
 type PromStatistics struct {
-	Falco   *prometheus.CounterVec
 	Inputs  *prometheus.CounterVec
 	Outputs *prometheus.CounterVec
 }

--- a/types/types.go
+++ b/types/types.go
@@ -64,7 +64,6 @@ type Configuration struct {
 	Customfields       map[string]string
 	Customtags         []string
 	Templatedfields    map[string]string
-	Prometheus         prometheusOutputConfig
 	Slack              SlackOutputConfig
 	Cliq               CliqOutputConfig
 	Mattermost         MattermostOutputConfig
@@ -359,11 +358,6 @@ type SumoLogicOutputConfig struct {
 	SourceCategory  string
 	SourceHost      string
 	Name            string
-}
-
-type prometheusOutputConfig struct {
-	ExtraLabels     string
-	ExtraLabelsList []string
 }
 
 type natsOutputConfig struct {

--- a/types/types.go
+++ b/types/types.go
@@ -81,7 +81,6 @@ type Configuration struct {
 	Customfields       map[string]string
 	Customtags         []string
 	Templatedfields    map[string]string
-	Prometheus         prometheusOutputConfig
 	Slack              SlackOutputConfig
 	Cliq               CliqOutputConfig
 	Mattermost         MattermostOutputConfig
@@ -376,11 +375,6 @@ type SumoLogicOutputConfig struct {
 	SourceCategory  string
 	SourceHost      string
 	Name            string
-}
-
-type prometheusOutputConfig struct {
-	ExtraLabels     string
-	ExtraLabelsList []string
 }
 
 type natsOutputConfig struct {

--- a/types/types.go
+++ b/types/types.go
@@ -976,7 +976,6 @@ type Statistics struct {
 
 // PromStatistics is a struct to store prometheus metrics
 type PromStatistics struct {
-	Falco   *prometheus.CounterVec
 	Inputs  *prometheus.CounterVec
 	Outputs *prometheus.CounterVec
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area config

> /area outputs

> /area tests


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Addresses an issue where sidekick is ooming due to high cardinality metric collection. Per the conversation here https://github.com/falcosecurity/falcosidekick/issues/1132, rather than toggling the metric on/off, removal of the metric entirely is preferred since the Falco binary itself now exports equivalent data. 

**Which issue(s) this PR fixes**:
https://github.com/falcosecurity/falcosidekick/issues/1132

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1132

**Special notes for your reviewer**:
While testing this fix, I submitted 1,000 fake messages to sidekick:

```
for i in $(seq 1 1000); do
  curl -s -X POST http://localhost:2801/ -H "Content-Type: application/json" -d "{
    \"output\": \"Test event from curl\",
    \"priority\": \"Debug\",
    \"rule\": \"Test rule\",
    \"time\": \"2025-11-24T12:00:00Z\",
    \"hostname\": \"testhost$i\",
    \"source\": \"syscalls\",
    \"output_fields\": {
      \"proc.name\": \"curl\",
      \"user.name\": \"tester\"
    },
    \"tags\": [\"test\", \"curl\"]
  }"
done
```

Then outputted the prom scrape to a file:
```
 ~/Desktop/falco-testing/ du -hs *
 12K     without_ falco_events.prom
180K   with_ falco_events old.prom
```

Where `without_ falco_events.prom` is the file generated by sidekick using this branch.