### PR TITLE
fix(metrics): sanitize custom field names before Prometheus & OTLP validation 

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -108,14 +108,15 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	var customFields string
 	if len(config.Customfields) > 0 {
-		if falcopayload.OutputFields == nil {
-			falcopayload.OutputFields = make(map[string]interface{})
-		}
-		for key, value := range config.Customfields {
-			customFields += key + "=" + value + " "
-			falcopayload.OutputFields[key] = value
-		}
-	}
+    if falcopayload.OutputFields == nil {
+        falcopayload.OutputFields = make(map[string]interface{})
+    }
+    for key, value := range config.Customfields {
+        sanitizedKey := strings.ReplaceAll(key, ".", "_")
+        customFields += sanitizedKey + "=" + value + " "
+        falcopayload.OutputFields[sanitizedKey] = value
+    }
+}
 
 	falcopayload.Tags = append(falcopayload.Tags, config.Customtags...)
 
@@ -182,8 +183,9 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	}
 
 	for key, value := range config.Customfields {
-		if regPromLabels.MatchString(key) {
-			promLabels[key] = value
+		sanitizedKey := strings.ReplaceAll(key, ".", "_")
+		if regPromLabels.MatchString(sanitizedKey) {
+			promLabels[sanitizedKey] = value
 		}
 	}
 	for key := range config.Templatedfields {
@@ -220,10 +222,11 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	}
 
 	for key, value := range config.Customfields {
-		if regOTLPMetricsAttributes.MatchString(key) {
-			attrs = append(attrs, attribute.String(key, value))
-		}
-	}
+     sanitizedKey := strings.ReplaceAll(key, ".", "_")
+    if regOTLPMetricsAttributes.MatchString(sanitizedKey) {
+        attrs = append(attrs, attribute.String(sanitizedKey, value))
+    }
+}
 	for _, attr := range config.OTLP.Metrics.ExtraAttributesList {
 		attrName := strings.ReplaceAll(attr, ".", "_")
 		attrValue := ""

--- a/otlp_metrics.go
+++ b/otlp_metrics.go
@@ -55,13 +55,14 @@ func newOTLPFalcoMatchesCounter(config *types.Configuration) otlpmetrics.Counter
 		supportedAttributes = append(supportedAttributes, i)
 	}
 
-	for _, i := range config.OTLP.Metrics.ExtraAttributesList {
-		if !regOTLPLabels.MatchString(strings.ReplaceAll(i, ".", "_")) {
-			utils.Log(utils.ErrorLvl, "", fmt.Sprintf("Extra field '%v' is not a valid OTLP metric attribute name", i))
-			continue
-		}
-		supportedAttributes = append(supportedAttributes, strings.ReplaceAll(i, ".", "_"))
-	}
+    for i := range config.Customfields {
+        sanitizedAttr := strings.ReplaceAll(i, ".", "_")
+      if !regOTLPLabels.MatchString(sanitizedAttr) {
+        utils.Log(utils.WarningLvl, "", fmt.Sprintf("Custom field '%v' (sanitized to '%v') is not a valid OTLP metric attribute name", i, sanitizedAttr))
+        continue
+      }
+      supportedAttributes = append(supportedAttributes, sanitizedAttr)
+    }
 
 	name := "falcosecurity_falco_rules_matches_total"
 	description := "Number of times rules match"

--- a/stats_prometheus.go
+++ b/stats_prometheus.go
@@ -54,13 +54,14 @@ func getFalcoNewCounterVec(config *types.Configuration) *prometheus.CounterVec {
 		"k8s_ns_name",
 		"k8s_pod_name",
 	}
-	for i := range config.Customfields {
-		if !regPromLabels.MatchString(strings.ReplaceAll(i, ".", "_")) {
-			utils.Log(utils.ErrorLvl, "Prometheus", fmt.Sprintf("Custom field '%v' is not a valid prometheus label", i))
-			continue
-		}
-		labelnames = append(labelnames, strings.ReplaceAll(i, ".", "_"))
-	}
+    for i := range config.Customfields {
+    sanitizedLabel := strings.ReplaceAll(i, ".", "_")
+    if !regPromLabels.MatchString(sanitizedLabel) {
+        utils.Log(utils.ErrorLvl, "Prometheus", fmt.Sprintf("Custom field '%v' (sanitized to '%v') is not a valid prometheus label", i, sanitizedLabel))
+        continue
+         }
+         labelnames = append(labelnames, sanitizedLabel)
+    }
 	for i := range config.Templatedfields {
 		if !regPromLabels.MatchString(strings.ReplaceAll(i, ".", "_")) {
 			utils.Log(utils.ErrorLvl, "Prometheus", fmt.Sprintf("Templated field '%v' is not a valid prometheus label", i))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source here: https://falco.org/docs/source.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it, specify a wip in the title.
-->

**What type of PR is this?**

/kind bug

---

**Any specific area of the project related to this PR?**

/area config  
/area outputs

---

**What this PR does / why we need it**:

Falco Sidekick currently panics when a custom field contains dots (e.g., `k8s.cluster.name`).  
Prometheus and OTLP both reject such attribute/label names, causing:

- OTLP metric attribute validation failures  
- Prometheus CounterVec cardinality mismatches (`expected X values, got Y`)  
- Full runtime panic when pushing metrics

The root cause was that custom fields were **validated before sanitization**.

### ✔ This PR fixes the issue by:
- Sanitizing all custom field names using `"." → "_"` **before** validation  
- Applying sanitization consistently across:
  - `handlers.go`
  - `stats_prometheus.go`
  - `otlp_metrics.go`
  - `OTLP.Metrics.ExtraAttributesList`
- Ensuring Prometheus and OTLP accept all user-provided fields safely
- Updating logs to show both original and sanitized keys

This prevents crashes, ensures correct metric cardinality, and keeps behavior consistent across all backends.

---

**Which issue(s) this PR fixes**:

Fixes #3748

---

**Special notes for your reviewer**:

- This change is backward-compatible  
- Only invalid-but-sanitizable field names are modified  
- Prometheus and OTLP now behave consistently  
- Helpful log messages added:  
  `"Custom field 'k8s.cluster.name' (sanitized to 'k8s_cluster_name') is not valid and will be ignored"`  

cc @maintainer
