### PR TITLE
fix: replace dots with underscores in custom field metric labels

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -182,13 +182,15 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	}
 
 	for key, value := range config.Customfields {
-		if regPromLabels.MatchString(key) {
-			promLabels[key] = value
+		sanitizedKey := strings.ReplaceAll(key, ".", "_")
+		if regPromLabels.MatchString(sanitizedKey) {
+			promLabels[sanitizedKey] = value
 		}
 	}
 	for key := range config.Templatedfields {
-		if regPromLabels.MatchString(strings.ReplaceAll(key, ".", "_")) {
-			promLabels[key] = fmt.Sprintf("%v", falcopayload.OutputFields[key])
+		sanitizedKey := strings.ReplaceAll(key, ".", "_")
+		if regPromLabels.MatchString(sanitizedKey) {
+			promLabels[sanitizedKey] = fmt.Sprintf("%v", falcopayload.OutputFields[key])
 		}
 	}
 	for _, i := range config.Prometheus.ExtraLabelsList {
@@ -220,8 +222,9 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	}
 
 	for key, value := range config.Customfields {
-		if regOTLPMetricsAttributes.MatchString(key) {
-			attrs = append(attrs, attribute.String(key, value))
+		sanitizedKey := strings.ReplaceAll(key, ".", "_")
+		if regOTLPMetricsAttributes.MatchString(sanitizedKey) {
+			attrs = append(attrs, attribute.String(sanitizedKey, value))
 		}
 	}
 	for _, attr := range config.OTLP.Metrics.ExtraAttributesList {

--- a/otlp_metrics.go
+++ b/otlp_metrics.go
@@ -48,11 +48,12 @@ func newOTLPFalcoMatchesCounter(config *types.Configuration) otlpmetrics.Counter
 		"k8s_pod_name",
 	}
 	for i := range config.Customfields {
-		if !regOTLPLabels.MatchString(i) {
+		sanitized := strings.ReplaceAll(i, ".", "_")
+		if !regOTLPLabels.MatchString(sanitized) {
 			utils.Log(utils.ErrorLvl, "", fmt.Sprintf("Custom field '%v' is not a valid OTLP metric attribute name", i))
 			continue
 		}
-		supportedAttributes = append(supportedAttributes, i)
+		supportedAttributes = append(supportedAttributes, sanitized)
 	}
 
 	for _, i := range config.OTLP.Metrics.ExtraAttributesList {

--- a/stats_prometheus_test.go
+++ b/stats_prometheus_test.go
@@ -16,13 +16,17 @@ func TestFalcoNewCounterVec(t *testing.T) {
 	}
 	c.Customfields["test"] = "foo"
 	c.Customfields["should*fail"] = "bar"
+	c.Customfields["k8s.cluster.name"] = "my-cluster"
 
 	cv := getFalcoNewCounterVec(c)
-	shouldbe := []string{"hostname", "rule", "priority", "priority_raw", "source", "k8s_ns_name", "k8s_pod_name", "test"}
+	shouldbe := []string{"hostname", "rule", "priority", "priority_raw", "source", "k8s_ns_name", "k8s_pod_name", "k8s_cluster_name", "test"}
 	mm, err := cv.GetMetricWithLabelValues(shouldbe...)
 	if err != nil {
 		t.Errorf("Error getting Metrics from promauto")
 	}
 	metricDescString := mm.Desc().String()
-	require.Equal(t, metricDescString, "Desc{fqName: \"falcosecurity_falcosidekick_falco_events_total\", help: \"\", constLabels: {}, variableLabels: {hostname,rule,priority,priority_raw,source,k8s_ns_name,k8s_pod_name,test}}")
+	require.Contains(t, metricDescString, "k8s_cluster_name")
+	require.Contains(t, metricDescString, "test")
+	require.NotContains(t, metricDescString, "should*fail")
+	require.NotContains(t, metricDescString, "k8s.cluster.name")
 }


### PR DESCRIPTION
Fixes #1318

Custom fields containing dots (e.g. `k8s.cluster.name`) cause a panic in the Prometheus handler because initialization and runtime disagree on label name sanitization.

**Root cause:**
- `getFalcoNewCounterVec` (init) replaces dots with underscores: `k8s.cluster.name` -> `k8s_cluster_name`
- `newFalcoPayload` (runtime) checks the raw key against the label regex, which fails for dotted keys
- The label is silently skipped at runtime, producing fewer labels than the counter expects
- `CounterVec.With()` panics: `inconsistent label cardinality: expected N label values but got N-1`

**Fix:**
- Apply the same `strings.ReplaceAll(key, ".", "_")` at runtime for Prometheus custom fields and templated fields in `handlers.go`
- Apply the same sanitization for OTLP custom field attributes in `handlers.go` and `otlp_metrics.go`
- Update test to cover dotted custom field names

cc @leogr @Issif