### PR TITLE
fix: correct AWS Security Lake config examples

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -205,7 +205,7 @@ aws:
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
     # endpoint: "" # endpoint URL that overrides the default generated endpoint, use this for S3 compatible APIs
     # objectcannedacl: "bucket-owner-full-control" # Canned ACL (x-amz-acl) to use when creating the object
-  securitylake.:
+  securitylake:
     # bucket: "" # Bucket for AWS SecurityLake data, if not empty, AWS SecurityLake output is enabled
     # region: "" # Bucket Region  (mandatory)
     # prefix: "" # Prefix for keys  (mandatory)

--- a/docs/outputs/aws_security_lake.md
+++ b/docs/outputs/aws_security_lake.md
@@ -43,7 +43,7 @@ aws:
   # rolearn: "" # aws role to assume (optional if you use EC2 Instance Profile)
   # externalid: "" # external id for the role to assume (optional if you use EC2 Instance Profile)
   # checkidentity: true # check the identity credentials, set to false for locale developments (default: true)
-  securitylake.:
+  securitylake:
     bucket: "" # Bucket for AWS SecurityLake data, if not empty, AWS SecurityLake output is enabled
     region: "" # Bucket Region
     prefix: "" # Prefix for keys


### PR DESCRIPTION
/kind documentation

/area config

**What this PR does / why we need it**:

Fixes the AWS Security Lake examples to use `securitylake:` instead of `securitylake.:`.

Small papercut, but copy-pasting the old YAML makes Viper read a different key, so `aws.securitylake.*` values don't get set. Kinda easy to miss.

Repro:

```yaml
aws:
  securitylake.:
    bucket: my-bucket
```

Load that config and `AWS.SecurityLake.Bucket` stays empty. With `securitylake:`, it maps to the documented `aws.securitylake.bucket` key.

**Which issue(s) this PR fixes**:

None found.

**Special notes for your reviewer**:

`go test ./...` passes.
