### PR TITLE
fix(telegram): bind MessageThreadID env var to fix ignored topic routing

### DIFF
--- a/config.go
+++ b/config.go
@@ -405,6 +405,7 @@ var outputDefaults = map[string]map[string]any{
 	"Telegram": {
 		"Token":           "",
 		"ChatID":          "",
+		"MessageThreadID": "",
 		"MinimumPriority": "",
 		"CheckCert":       true,
 	},

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -501,6 +501,7 @@ redis:
 telegram:
   # token: "" # telegram bot authentication token
   # chatid: "" # telegram Identifier of the shared chat
+  # messagethreadid: "" # telegram individual chats (topics) within the group
   # checkcert: true # check if ssl certificate of the output is valid (default: true)
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falcosidekick/types"
+)
+
+// TestTelegramMessageThreadIDDefaultRegistered guards against regression of #1283:
+// the MessageThreadID env var (TELEGRAM_MESSAGETHREADID) and yaml key
+// (telegram.messagethreadid) only bind to Configuration.Telegram.MessageThreadID
+// when the key is registered in outputDefaults so viper's AutomaticEnv knows about it.
+func TestTelegramMessageThreadIDDefaultRegistered(t *testing.T) {
+	telegramDefaults, ok := outputDefaults["Telegram"]
+	require.True(t, ok, "outputDefaults must contain Telegram entry")
+	_, present := telegramDefaults["MessageThreadID"]
+	require.True(t, present, "outputDefaults[\"Telegram\"] must register MessageThreadID for viper env binding to work")
+}
+
+// TestTelegramMessageThreadIDEnvBinding exercises the same viper setup getConfig()
+// uses (SetDefault from outputDefaults + AutomaticEnv with "." -> "_" replacer) and
+// confirms TELEGRAM_MESSAGETHREADID flows into Configuration.Telegram.MessageThreadID.
+// Without the outputDefaults entry this test fails: viper's AutomaticEnv only binds
+// keys it has seen via SetDefault during Unmarshal.
+func TestTelegramMessageThreadIDEnvBinding(t *testing.T) {
+	t.Setenv("TELEGRAM_MESSAGETHREADID", "4")
+
+	v := viper.New()
+	for prefix, m := range outputDefaults {
+		for key, val := range m {
+			v.SetDefault(prefix+"."+key, val)
+		}
+	}
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.AutomaticEnv()
+
+	c := &types.Configuration{}
+	require.NoError(t, v.Unmarshal(c))
+	require.Equal(t, "4", c.Telegram.MessageThreadID)
+}

--- a/docs/outputs/telegram.md
+++ b/docs/outputs/telegram.md
@@ -16,10 +16,10 @@
 
 | Setting                    | Env var                    | Default value    | Description                                                                                                                         |
 | -------------------------- | -------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `telegram.chatid`          | `TELEGRAM_CHATID`          |                  | Telegram Identifier of the shared chat, if not empty, Telegram is **enabled**                                                       |
-| `telegram.token`           | `TELEGRAM_TOKEN`           |                  | Telegram bot authentication token                                                                                                   |
-  `telegram.message_thread_id` | `TELEGRAM_MESSAGE_THREAD_ID` |              | Telegram individual chats within the group
-| `telegram.minimumpriority` | `TELEGRAM_MINIMUMPRIORITY` | `""` (= `debug`) | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
+| `telegram.chatid`           | `TELEGRAM_CHATID`           |                  | Telegram Identifier of the shared chat, if not empty, Telegram is **enabled**                                                       |
+| `telegram.token`            | `TELEGRAM_TOKEN`            |                  | Telegram bot authentication token                                                                                                   |
+| `telegram.messagethreadid`  | `TELEGRAM_MESSAGETHREADID`  |                  | Telegram individual chats within the group                                                                                          |
+| `telegram.minimumpriority`  | `TELEGRAM_MINIMUMPRIORITY`  | `""` (= `debug`) | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
 
 > [!NOTE]
 The Env var values override the settings from yaml file.
@@ -30,7 +30,7 @@ The Env var values override the settings from yaml file.
 telegram:
   chatid: "" # Telegram Identifier of the shared chat, if not empty, Telegram is enabled
   token: "" # Telegram bot authentication token
-  # message_thread_id: "" # Telegram individual chats within the group
+  # messagethreadid: "" # Telegram individual chats within the group
   # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
 ```
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs

**Does this PR require a change in the documentation?**

Yes, updated `docs/outputs/telegram.md` and `config_example.yaml` in this PR.

**What this PR does / why we need it**:

Closes #1283.

`Telegram.MessageThreadID` was missing from the `outputDefaults` map in `config.go`, so viper's `AutomaticEnv` had no key to bind during `Unmarshal`. Result: setting `TELEGRAM_MESSAGETHREADID` (or its yaml counterpart) had no effect, and Telegram messages always landed in the general topic regardless of `message_thread_id`.

The struct field, JSON tag, and payload wiring were already in place (`types/types.go`, `outputs/telegram.go`); the only missing piece was the viper default registration that the rest of `Telegram` already relied on.

**Changes**:

- Register `Telegram.MessageThreadID` in `outputDefaults`. One-line fix; the env var and yaml key now bind correctly.
- Add `config_test.go` with two regression tests: one asserts the defaults entry is registered, the other exercises the same viper setup `getConfig()` uses and confirms `TELEGRAM_MESSAGETHREADID=4` ends up at `c.Telegram.MessageThreadID`.
- Fix `docs/outputs/telegram.md` and `config_example.yaml` to use `TELEGRAM_MESSAGETHREADID` / `messagethreadid`, matching the project's naming convention (e.g. `AWS_SECRETACCESSKEY`). The previous underscored form `TELEGRAM_MESSAGE_THREAD_ID` does not bind through viper's env replacer.

**Verification**:

- `go test ./...` passes.
- The new `TestTelegramMessageThreadIDEnvBinding` fails on the pre-fix code (verified via `git stash` of `config.go`) and passes after the fix.

**Special notes for your reviewer**:

The yaml key in the existing docs (`message_thread_id`) likewise did not bind, since viper preserves underscores in keys and mapstructure compares to struct fields case-insensitively but otherwise literal. Both env var and yaml docs are aligned in this PR.