### PR TITLE
fix(aws): use AWSConfig for S3 client in UploadS3

### DIFF
--- a/outputs/aws.go
+++ b/outputs/aws.go
@@ -159,12 +159,12 @@ func (c *Client) UploadS3(falcopayload types.FalcoPayload) {
 	}
 
 	key := fmt.Sprintf("%s/%s/%s.json", prefix, t.Format("2006-01-02"), t.Format(time.RFC3339Nano))
-	awsConfig := aws.NewConfig()
-	var client s3.Client
+	var client *s3.Client
 	if c.Config.AWS.S3.Endpoint != "" {
-		s3.NewFromConfig(*awsConfig, s3.WithEndpointResolver(s3.EndpointResolverFromURL(c.Config.AWS.S3.Endpoint)))
+		client = s3.NewFromConfig(*c.AWSConfig,
+			s3.WithEndpointResolver(s3.EndpointResolverFromURL(c.Config.AWS.S3.Endpoint)))
 	} else {
-		client = *s3.NewFromConfig(*awsConfig)
+		client = s3.NewFromConfig(*c.AWSConfig)
 	}
 	resp, err := client.PutObject(context.Background(), &s3.PutObjectInput{
 		Bucket: aws.String(c.Config.AWS.S3.Bucket),


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

UploadS3 was creating the S3 client from an empty aws.NewConfig() after
the SDK v2 migration, causing Invalid region on PutObject despite valid
aws.region. Use c.AWSConfig like other AWS outputs and assign the client
in the custom endpoint branch.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1362

**Special notes for your reviewer**:


