### PR TITLE
fix: correct client logging for 500 and 502 responses

### DIFF
--- a/outputs/client.go
+++ b/outputs/client.go
@@ -422,12 +422,10 @@ func (c *Client) sendRequest(method string, payload interface{}, responseBody *s
 		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("%v (%v): %s", ErrTooManyRequest, resp.StatusCode, c.getInlinedBodyAsString(resp)))
 		return ErrTooManyRequest
 	case http.StatusInternalServerError: //500
-		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("%v (%v)", ErrTooManyRequest, resp.StatusCode))
+		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("%v (%v): %s", ErrInternalServer, resp.StatusCode, c.getInlinedBodyAsString(resp)))
 		return ErrInternalServer
 	case http.StatusBadGateway: //502
-		msg := c.getInlinedBodyAsString(resp)
-		fmt.Println(msg)
-		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("%v (%v)", ErrTooManyRequest, resp.StatusCode))
+		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("%v (%v): %s", ErrBadGateway, resp.StatusCode, c.getInlinedBodyAsString(resp)))
 		return ErrBadGateway
 	default:
 		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("unexpected Response (%v)", resp.StatusCode))

--- a/outputs/client_test.go
+++ b/outputs/client_test.go
@@ -11,12 +11,14 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -97,6 +99,77 @@ func TestPost(t *testing.T) {
 
 		errPost := nc.Post("")
 		require.Equal(t, errPost, j)
+	}
+}
+
+func TestPostServerErrorsLogCorrectErrorAndDoNotWriteStdout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/500":
+			http.Error(w, "upstream exploded", http.StatusInternalServerError)
+		case "/502":
+			http.Error(w, "temporary proxy failure", http.StatusBadGateway)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.EscapedPath())
+		}
+	}))
+	defer ts.Close()
+
+	testCases := []struct {
+		path         string
+		expectedErr  error
+		expectedLog  string
+		unwantedLog  string
+	}{
+		{
+			path:        "/500",
+			expectedErr: ErrInternalServer,
+			expectedLog: ErrInternalServer.Error(),
+			unwantedLog: ErrTooManyRequest.Error(),
+		},
+		{
+			path:        "/502",
+			expectedErr: ErrBadGateway,
+			expectedLog: ErrBadGateway.Error(),
+			unwantedLog: ErrTooManyRequest.Error(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			initClientArgs := &types.InitClientArgs{
+				Config:    &types.Configuration{},
+				Stats:     &types.Statistics{},
+				PromStats: &types.PromStatistics{},
+			}
+			nc, err := NewClient("", ts.URL+tc.path, types.CommonConfig{CheckCert: true}, *initClientArgs)
+			require.NoError(t, err)
+
+			var logBuf bytes.Buffer
+			logWriter := log.Writer()
+			log.SetOutput(&logBuf)
+			defer log.SetOutput(logWriter)
+
+			oldStdout := os.Stdout
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdout = w
+			defer func() {
+				os.Stdout = oldStdout
+			}()
+
+			err = nc.Post("")
+
+			require.NoError(t, w.Close())
+			stdoutBytes, readErr := io.ReadAll(r)
+			require.NoError(t, readErr)
+			require.NoError(t, r.Close())
+
+			require.ErrorIs(t, err, tc.expectedErr)
+			require.Contains(t, logBuf.String(), tc.expectedLog)
+			require.NotContains(t, logBuf.String(), tc.unwantedLog)
+			require.Empty(t, string(stdoutBytes))
+		})
 	}
 }
 


### PR DESCRIPTION
/kind bug
/area outputs
/area tests

**What this PR does / why we need it**:

`sendRequest` was logging the 429 message for 500 and 502 by mistake. 502 also dumped the raw response body to stdout, which is kinda noisy and a bit of a footgun. This wires the right error logs and adds a regression test.

**Which issue(s) this PR fixes**:

None found, didnt see an existing issue for this one.

**Special notes for your reviewer**:

Repro:
1. Point any HTTP output at a server that returns `500` or `502`.
2. Send an event.
3. Before this patch, logs say `exceeding post rate limit (500|502)`, and `502` writes the body to stdout too.
4. With this patch, logs say `internal server error` or `bad gateway`, stdout stays clean.

Checks:
- `go test ./...`
- `go test -race ./outputs -run 'TestPost|TestPostServerErrorsLogCorrectErrorAndDoNotWriteStdout' -count=1`
