### PR TITLE
fix: prevent DoS panics from malformed output_fields in OTLP traces a…

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -296,275 +296,288 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	return falcopayload, nil
 }
 
+// safeGo runs fn in its own goroutine, recovering from any panic so that a single
+// malformed event or misbehaving output cannot bring down the whole process.
+func safeGo(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				utils.Log(utils.ErrorLvl, "", fmt.Sprintf("recovered from panic while forwarding event: %v", r))
+			}
+		}()
+		fn()
+	}()
+}
+
 func forwardEvent(falcopayload types.FalcoPayload) {
 	if config.Slack.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Slack.MinimumPriority) || falcopayload.Rule == testRule) {
-		go slackClient.SlackPost(falcopayload)
+		safeGo(func() { slackClient.SlackPost(falcopayload) })
 	}
 
 	if config.Cliq.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Cliq.MinimumPriority) || falcopayload.Rule == testRule) {
-		go cliqClient.CliqPost(falcopayload)
+		safeGo(func() { cliqClient.CliqPost(falcopayload) })
 	}
 
 	if config.Rocketchat.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Rocketchat.MinimumPriority) || falcopayload.Rule == testRule) {
-		go rocketchatClient.RocketchatPost(falcopayload)
+		safeGo(func() { rocketchatClient.RocketchatPost(falcopayload) })
 	}
 
 	if config.Mattermost.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Mattermost.MinimumPriority) || falcopayload.Rule == testRule) {
-		go mattermostClient.MattermostPost(falcopayload)
+		safeGo(func() { mattermostClient.MattermostPost(falcopayload) })
 	}
 
 	if config.Teams.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Teams.MinimumPriority) || falcopayload.Rule == testRule) {
-		go teamsClient.TeamsPost(falcopayload)
+		safeGo(func() { teamsClient.TeamsPost(falcopayload) })
 	}
 
 	if config.Webex.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Webex.MinimumPriority) || falcopayload.Rule == testRule) {
-		go webexClient.WebexPost(falcopayload)
+		safeGo(func() { webexClient.WebexPost(falcopayload) })
 	}
 
 	if config.Datadog.APIKey != "" && (falcopayload.Priority >= types.Priority(config.Datadog.MinimumPriority) || falcopayload.Rule == testRule) {
-		go datadogClient.DatadogPost(falcopayload)
+		safeGo(func() { datadogClient.DatadogPost(falcopayload) })
 	}
 
 	if config.DatadogLogs.APIKey != "" && (falcopayload.Priority >= types.Priority(config.DatadogLogs.MinimumPriority) || falcopayload.Rule == testRule) {
-		go datadogLogsClient.DatadogLogsPost(falcopayload)
+		safeGo(func() { datadogLogsClient.DatadogLogsPost(falcopayload) })
 	}
 
 	if config.Discord.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Discord.MinimumPriority) || falcopayload.Rule == testRule) {
-		go discordClient.DiscordPost(falcopayload)
+		safeGo(func() { discordClient.DiscordPost(falcopayload) })
 	}
 
 	if len(config.Alertmanager.HostPort) != 0 && (falcopayload.Priority >= types.Priority(config.Alertmanager.MinimumPriority) || falcopayload.Rule == testRule) {
 		for _, i := range alertmanagerClients {
-			go i.AlertmanagerPost(falcopayload)
+			safeGo(func() { i.AlertmanagerPost(falcopayload) })
 		}
 	}
 
 	if config.Elasticsearch.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Elasticsearch.MinimumPriority) || falcopayload.Rule == testRule) {
-		go elasticsearchClient.ElasticsearchPost(falcopayload)
+		safeGo(func() { elasticsearchClient.ElasticsearchPost(falcopayload) })
 	}
 
 	if config.Quickwit.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Quickwit.MinimumPriority) || falcopayload.Rule == testRule) {
-		go quickwitClient.QuickwitPost(falcopayload)
+		safeGo(func() { quickwitClient.QuickwitPost(falcopayload) })
 	}
 
 	if config.Influxdb.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Influxdb.MinimumPriority) || falcopayload.Rule == testRule) {
-		go influxdbClient.InfluxdbPost(falcopayload)
+		safeGo(func() { influxdbClient.InfluxdbPost(falcopayload) })
 	}
 
 	if config.Loki.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Loki.MinimumPriority) || falcopayload.Rule == testRule) {
-		go lokiClient.LokiPost(falcopayload)
+		safeGo(func() { lokiClient.LokiPost(falcopayload) })
 	}
 
 	if config.SumoLogic.ReceiverURL != "" && (falcopayload.Priority >= types.Priority(config.SumoLogic.MinimumPriority) || falcopayload.Rule == testRule) {
-		go sumologicClient.SumoLogicPost(falcopayload)
+		safeGo(func() { sumologicClient.SumoLogicPost(falcopayload) })
 	}
 
 	if config.Nats.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Nats.MinimumPriority) || falcopayload.Rule == testRule) {
-		go natsClient.NatsPublish(falcopayload)
+		safeGo(func() { natsClient.NatsPublish(falcopayload) })
 	}
 
 	if config.Stan.HostPort != "" && config.Stan.ClusterID != "" && config.Stan.ClientID != "" && (falcopayload.Priority >= types.Priority(config.Stan.MinimumPriority) || falcopayload.Rule == testRule) {
-		go stanClient.StanPublish(falcopayload)
+		safeGo(func() { stanClient.StanPublish(falcopayload) })
 	}
 
 	if config.AWS.Lambda.FunctionName != "" && (falcopayload.Priority >= types.Priority(config.AWS.Lambda.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.InvokeLambda(falcopayload)
+		safeGo(func() { awsClient.InvokeLambda(falcopayload) })
 	}
 
 	if config.AWS.SQS.URL != "" && (falcopayload.Priority >= types.Priority(config.AWS.SQS.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.SendMessage(falcopayload)
+		safeGo(func() { awsClient.SendMessage(falcopayload) })
 	}
 
 	if config.AWS.SNS.TopicArn != "" && (falcopayload.Priority >= types.Priority(config.AWS.SNS.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.PublishTopic(falcopayload)
+		safeGo(func() { awsClient.PublishTopic(falcopayload) })
 	}
 
 	if config.AWS.CloudWatchLogs.LogGroup != "" && (falcopayload.Priority >= types.Priority(config.AWS.CloudWatchLogs.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.SendCloudWatchLog(falcopayload)
+		safeGo(func() { awsClient.SendCloudWatchLog(falcopayload) })
 	}
 
 	if config.AWS.S3.Bucket != "" && (falcopayload.Priority >= types.Priority(config.AWS.S3.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.UploadS3(falcopayload)
+		safeGo(func() { awsClient.UploadS3(falcopayload) })
 	}
 
 	if (config.AWS.SecurityLake.Bucket != "" && config.AWS.SecurityLake.Region != "" && config.AWS.SecurityLake.AccountID != "" && config.AWS.SecurityLake.Prefix != "") && (falcopayload.Priority >= types.Priority(config.AWS.SecurityLake.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.EnqueueSecurityLake(falcopayload)
+		safeGo(func() { awsClient.EnqueueSecurityLake(falcopayload) })
 	}
 
 	if config.AWS.Kinesis.StreamName != "" && (falcopayload.Priority >= types.Priority(config.AWS.Kinesis.MinimumPriority) || falcopayload.Rule == testRule) {
-		go awsClient.PutRecord(falcopayload)
+		safeGo(func() { awsClient.PutRecord(falcopayload) })
 	}
 
 	if config.SMTP.HostPort != "" && (falcopayload.Priority >= types.Priority(config.SMTP.MinimumPriority) || falcopayload.Rule == testRule) {
-		go smtpClient.SendMail(falcopayload)
+		safeGo(func() { smtpClient.SendMail(falcopayload) })
 	}
 
 	if config.Opsgenie.APIKey != "" && (falcopayload.Priority >= types.Priority(config.Opsgenie.MinimumPriority) || falcopayload.Rule == testRule) {
-		go opsgenieClient.OpsgeniePost(falcopayload)
+		safeGo(func() { opsgenieClient.OpsgeniePost(falcopayload) })
 	}
 
 	if config.Webhook.Address != "" && (falcopayload.Priority >= types.Priority(config.Webhook.MinimumPriority) || falcopayload.Rule == testRule) {
-		go webhookClient.WebhookPost(falcopayload)
+		safeGo(func() { webhookClient.WebhookPost(falcopayload) })
 	}
 
 	if config.Splunk.Host != "" && (falcopayload.Priority >= types.Priority(config.Splunk.MinimumPriority) || falcopayload.Rule == testRule) {
-		go splunkClient.Send(falcopayload)
+		safeGo(func() { splunkClient.Send(falcopayload) })
 	}
 
 	if config.NodeRed.Address != "" && (falcopayload.Priority >= types.Priority(config.NodeRed.MinimumPriority) || falcopayload.Rule == testRule) {
-		go noderedClient.NodeRedPost(falcopayload)
+		safeGo(func() { noderedClient.NodeRedPost(falcopayload) })
 	}
 
 	if config.CloudEvents.Address != "" && (falcopayload.Priority >= types.Priority(config.CloudEvents.MinimumPriority) || falcopayload.Rule == testRule) {
-		go cloudeventsClient.CloudEventsSend(falcopayload)
+		safeGo(func() { cloudeventsClient.CloudEventsSend(falcopayload) })
 	}
 
 	if config.Azure.EventHub.Name != "" && (falcopayload.Priority >= types.Priority(config.Azure.EventHub.MinimumPriority) || falcopayload.Rule == testRule) {
-		go azureClient.EventHubPost(falcopayload)
+		safeGo(func() { azureClient.EventHubPost(falcopayload) })
 	}
 
 	if config.GCP.PubSub.ProjectID != "" && config.GCP.PubSub.Topic != "" && (falcopayload.Priority >= types.Priority(config.GCP.PubSub.MinimumPriority) || falcopayload.Rule == testRule) {
-		go gcpClient.GCPPublishTopic(falcopayload)
+		safeGo(func() { gcpClient.GCPPublishTopic(falcopayload) })
 	}
 
 	if config.GCP.CloudFunctions.Name != "" && (falcopayload.Priority >= types.Priority(config.GCP.CloudFunctions.MinimumPriority) || falcopayload.Rule == testRule) {
-		go gcpClient.GCPCallCloudFunction(falcopayload)
+		safeGo(func() { gcpClient.GCPCallCloudFunction(falcopayload) })
 	}
 
 	if config.GCP.CloudRun.Endpoint != "" && (falcopayload.Priority >= types.Priority(config.GCP.CloudRun.MinimumPriority) || falcopayload.Rule == testRule) {
-		go gcpCloudRunClient.CloudRunFunctionPost(falcopayload)
+		safeGo(func() { gcpCloudRunClient.CloudRunFunctionPost(falcopayload) })
 	}
 
 	if config.GCP.Storage.Bucket != "" && (falcopayload.Priority >= types.Priority(config.GCP.Storage.MinimumPriority) || falcopayload.Rule == testRule) {
-		go gcpClient.UploadGCS(falcopayload)
+		safeGo(func() { gcpClient.UploadGCS(falcopayload) })
 	}
 
 	if config.GCP.Chronicle.Region != "" && config.GCP.Chronicle.ProjectID != "" && config.GCP.Chronicle.InstanceID != "" && gcpClient != nil && (falcopayload.Priority >= types.Priority(config.GCP.Chronicle.MinimumPriority) || falcopayload.Rule == testRule) {
-		go gcpClient.GCPChronicleIngest(falcopayload)
+		safeGo(func() { gcpClient.GCPChronicleIngest(falcopayload) })
 	}
 
 	if config.Googlechat.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Googlechat.MinimumPriority) || falcopayload.Rule == testRule) {
-		go googleChatClient.GooglechatPost(falcopayload)
+		safeGo(func() { googleChatClient.GooglechatPost(falcopayload) })
 	}
 
 	if config.Kafka.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Kafka.MinimumPriority) || falcopayload.Rule == testRule) {
-		go kafkaClient.KafkaProduce(falcopayload)
+		safeGo(func() { kafkaClient.KafkaProduce(falcopayload) })
 	}
 
 	if config.KafkaRest.Address != "" && (falcopayload.Priority >= types.Priority(config.KafkaRest.MinimumPriority) || falcopayload.Rule == testRule) {
-		go kafkaRestClient.KafkaRestPost(falcopayload)
+		safeGo(func() { kafkaRestClient.KafkaRestPost(falcopayload) })
 	}
 
 	if config.Pagerduty.RoutingKey != "" && (falcopayload.Priority >= types.Priority(config.Pagerduty.MinimumPriority) || falcopayload.Rule == testRule) {
-		go pagerdutyClient.PagerdutyPost(falcopayload)
+		safeGo(func() { pagerdutyClient.PagerdutyPost(falcopayload) })
 	}
 
 	if config.Kubeless.Namespace != "" && config.Kubeless.Function != "" && (falcopayload.Priority >= types.Priority(config.Kubeless.MinimumPriority) || falcopayload.Rule == testRule) {
-		go kubelessClient.KubelessCall(falcopayload)
+		safeGo(func() { kubelessClient.KubelessCall(falcopayload) })
 	}
 
 	if config.Openfaas.FunctionName != "" && (falcopayload.Priority >= types.Priority(config.Openfaas.MinimumPriority) || falcopayload.Rule == testRule) {
-		go openfaasClient.OpenfaasCall(falcopayload)
+		safeGo(func() { openfaasClient.OpenfaasCall(falcopayload) })
 	}
 
 	if config.Tekton.EventListener != "" && (falcopayload.Priority >= types.Priority(config.Tekton.MinimumPriority) || falcopayload.Rule == testRule) {
-		go tektonClient.TektonPost(falcopayload)
+		safeGo(func() { tektonClient.TektonPost(falcopayload) })
 	}
 
 	if config.Rabbitmq.URL != "" && config.Rabbitmq.Queue != "" && (falcopayload.Priority >= types.Priority(config.Rabbitmq.MinimumPriority) || falcopayload.Rule == testRule) {
-		go rabbitmqClient.Publish(falcopayload)
+		safeGo(func() { rabbitmqClient.Publish(falcopayload) })
 	}
 
 	if config.Wavefront.EndpointHost != "" && config.Wavefront.EndpointType != "" && (falcopayload.Priority >= types.Priority(config.Wavefront.MinimumPriority) || falcopayload.Rule == testRule) {
-		go wavefrontClient.WavefrontPost(falcopayload)
+		safeGo(func() { wavefrontClient.WavefrontPost(falcopayload) })
 	}
 
 	if config.Grafana.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Grafana.MinimumPriority) || falcopayload.Rule == testRule) {
-		go grafanaClient.GrafanaPost(falcopayload)
+		safeGo(func() { grafanaClient.GrafanaPost(falcopayload) })
 	}
 
 	if config.GrafanaOnCall.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.GrafanaOnCall.MinimumPriority) || falcopayload.Rule == testRule) {
-		go grafanaOnCallClient.GrafanaOnCallPost(falcopayload)
+		safeGo(func() { grafanaOnCallClient.GrafanaOnCallPost(falcopayload) })
 	}
 
 	if config.WebUI.URL != "" {
-		go webUIClient.WebUIPost(falcopayload)
+		safeGo(func() { webUIClient.WebUIPost(falcopayload) })
 	}
 
 	if config.Fission.Function != "" && (falcopayload.Priority >= types.Priority(config.Fission.MinimumPriority) || falcopayload.Rule == testRule) {
-		go fissionClient.FissionCall(falcopayload)
+		safeGo(func() { fissionClient.FissionCall(falcopayload) })
 	}
 	if config.PolicyReport.Enabled && (falcopayload.Priority >= types.Priority(config.PolicyReport.MinimumPriority)) {
 		if falcopayload.Source == syscalls || falcopayload.Source == syscall || falcopayload.Source == "k8saudit" {
-			go policyReportClient.UpdateOrCreatePolicyReport(falcopayload)
+			safeGo(func() { policyReportClient.UpdateOrCreatePolicyReport(falcopayload) })
 		}
 	}
 
 	if config.Yandex.S3.Bucket != "" && (falcopayload.Priority >= types.Priority(config.Yandex.S3.MinimumPriority) || falcopayload.Rule == testRule) {
-		go yandexClient.UploadYandexS3(falcopayload)
+		safeGo(func() { yandexClient.UploadYandexS3(falcopayload) })
 	}
 
 	if config.Yandex.DataStreams.StreamName != "" && (falcopayload.Priority >= types.Priority(config.Yandex.DataStreams.MinimumPriority) || falcopayload.Rule == testRule) {
-		go yandexClient.UploadYandexDataStreams(falcopayload)
+		safeGo(func() { yandexClient.UploadYandexDataStreams(falcopayload) })
 	}
 
 	if config.Syslog.Host != "" && (falcopayload.Priority >= types.Priority(config.Syslog.MinimumPriority) || falcopayload.Rule == testRule) {
-		go syslogClient.SyslogPost(falcopayload)
+		safeGo(func() { syslogClient.SyslogPost(falcopayload) })
 	}
 
 	if config.MQTT.Broker != "" && (falcopayload.Priority >= types.Priority(config.MQTT.MinimumPriority) || falcopayload.Rule == testRule) {
-		go mqttClient.MQTTPublish(falcopayload)
+		safeGo(func() { mqttClient.MQTTPublish(falcopayload) })
 	}
 
 	if config.Zincsearch.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Zincsearch.MinimumPriority) || falcopayload.Rule == testRule) {
-		go zincsearchClient.ZincsearchPost(falcopayload)
+		safeGo(func() { zincsearchClient.ZincsearchPost(falcopayload) })
 	}
 
 	if config.Gotify.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Gotify.MinimumPriority) || falcopayload.Rule == testRule) {
-		go gotifyClient.GotifyPost(falcopayload)
+		safeGo(func() { gotifyClient.GotifyPost(falcopayload) })
 	}
 
 	if config.Spyderbat.OrgUID != "" && (falcopayload.Priority >= types.Priority(config.Spyderbat.MinimumPriority) || falcopayload.Rule == testRule) {
-		go spyderbatClient.SpyderbatPost(falcopayload)
+		safeGo(func() { spyderbatClient.SpyderbatPost(falcopayload) })
 	}
 
 	if config.TimescaleDB.Host != "" && (falcopayload.Priority >= types.Priority(config.TimescaleDB.MinimumPriority) || falcopayload.Rule == testRule) {
-		go timescaleDBClient.TimescaleDBPost(falcopayload)
+		safeGo(func() { timescaleDBClient.TimescaleDBPost(falcopayload) })
 	}
 
 	if config.Redis.Address != "" && (falcopayload.Priority >= types.Priority(config.Redis.MinimumPriority) || falcopayload.Rule == testRule) {
-		go redisClient.RedisPost(falcopayload)
+		safeGo(func() { redisClient.RedisPost(falcopayload) })
 	}
 
 	if config.Telegram.ChatID != "" && config.Telegram.Token != "" && (falcopayload.Priority >= types.Priority(config.Telegram.MinimumPriority) || falcopayload.Rule == testRule) {
-		go telegramClient.TelegramPost(falcopayload)
+		safeGo(func() { telegramClient.TelegramPost(falcopayload) })
 	}
 
 	if config.N8N.Address != "" && (falcopayload.Priority >= types.Priority(config.N8N.MinimumPriority) || falcopayload.Rule == testRule) {
-		go n8nClient.N8NPost(falcopayload)
+		safeGo(func() { n8nClient.N8NPost(falcopayload) })
 	}
 
 	if config.OpenObserve.HostPort != "" && (falcopayload.Priority >= types.Priority(config.OpenObserve.MinimumPriority) || falcopayload.Rule == testRule) {
-		go openObserveClient.OpenObservePost(falcopayload)
+		safeGo(func() { openObserveClient.OpenObservePost(falcopayload) })
 	}
 
 	if config.Dynatrace.APIToken != "" && config.Dynatrace.APIUrl != "" && (falcopayload.Priority >= types.Priority(config.Dynatrace.MinimumPriority) || falcopayload.Rule == testRule) {
-		go dynatraceClient.DynatracePost(falcopayload)
+		safeGo(func() { dynatraceClient.DynatracePost(falcopayload) })
 	}
 
 	if config.OTLP.Traces.Endpoint != "" && (falcopayload.Priority >= types.Priority(config.OTLP.Traces.MinimumPriority)) && (falcopayload.Source == syscall || falcopayload.Source == syscalls) {
-		go otlpTracesClient.OTLPTracesPost(falcopayload)
+		safeGo(func() { otlpTracesClient.OTLPTracesPost(falcopayload) })
 	}
 
 	if config.OTLP.Logs.Endpoint != "" && (falcopayload.Priority >= types.Priority(config.OTLP.Logs.MinimumPriority)) {
-		go otlpLogsClient.OTLPLogsPost(falcopayload)
+		safeGo(func() { otlpLogsClient.OTLPLogsPost(falcopayload) })
 	}
 
 	if config.Talon.Address != "" && (falcopayload.Priority >= types.Priority(config.Talon.MinimumPriority) || falcopayload.Rule == testRule) {
-		go talonClient.TalonPost(falcopayload)
+		safeGo(func() { talonClient.TalonPost(falcopayload) })
 	}
 
 	if config.Logstash.Address != "" && (falcopayload.Priority >= types.Priority(config.Logstash.MinimumPriority) || falcopayload.Rule == testRule) {
-		go logstashClient.LogstashPost(falcopayload)
+		safeGo(func() { logstashClient.LogstashPost(falcopayload) })
 	}
 }

--- a/outputs/otlp_traces.go
+++ b/outputs/otlp_traces.go
@@ -108,20 +108,10 @@ func (c *Client) OTLPTracesPost(falcopayload types.FalcoPayload) {
 }
 
 func generateTraceID(falcopayload types.FalcoPayload) (trace.TraceID, error) {
-	var k8sNsName, k8sPodName, containerId, evtHostname string
-
-	if falcopayload.OutputFields["k8s.ns.name"] != nil {
-		k8sNsName = falcopayload.OutputFields["k8s.ns.name"].(string)
-	}
-	if falcopayload.OutputFields["k8s.pod.name"] != nil {
-		k8sPodName = falcopayload.OutputFields["k8s.pod.name"].(string)
-	}
-	if falcopayload.OutputFields["container.id"] != nil {
-		containerId = falcopayload.OutputFields["container.id"].(string)
-	}
-	if falcopayload.OutputFields["evt.hostname"] != nil {
-		evtHostname = falcopayload.OutputFields["evt.hostname"].(string)
-	}
+	k8sNsName, _ := falcopayload.OutputFields["k8s.ns.name"].(string)
+	k8sPodName, _ := falcopayload.OutputFields["k8s.pod.name"].(string)
+	containerId, _ := falcopayload.OutputFields["container.id"].(string)
+	evtHostname, _ := falcopayload.OutputFields["evt.hostname"].(string)
 
 	var traceIDStr string
 	if k8sNsName != "" && k8sPodName != "" {

--- a/outputs/otlp_traces_test.go
+++ b/outputs/otlp_traces_test.go
@@ -3,6 +3,7 @@
 package outputs
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -107,4 +108,65 @@ func TestOtlpNewTrace(t *testing.T) {
 		cases[idx].actualTraceID = c.actualTraceID
 	}
 	// 2nd pass to verify cross-case traceID comparisons (equality, difference)
+}
+
+// TestGenerateTraceIDWithNonStringFields ensures that non-string values in the
+// output fields used to build the trace ID do not panic. These fields come from
+// attacker-influenceable payloads, so a bare type assertion would panic and, since
+// generateTraceID runs in its own goroutine, crash the whole process.
+func TestGenerateTraceIDWithNonStringFields(t *testing.T) {
+	cases := []struct {
+		msg string
+		fp  types.FalcoPayload
+	}{
+		{
+			msg: "container.id as a JSON number",
+			fp: types.FalcoPayload{
+				OutputFields: map[string]interface{}{
+					"container.id": json.Number("42"),
+				},
+			},
+		},
+		{
+			msg: "k8s fields as bool and number",
+			fp: types.FalcoPayload{
+				OutputFields: map[string]interface{}{
+					"k8s.ns.name":  true,
+					"k8s.pod.name": json.Number("1"),
+				},
+			},
+		},
+		{
+			msg: "evt.hostname as a nested object",
+			fp: types.FalcoPayload{
+				OutputFields: map[string]interface{}{
+					"evt.hostname": map[string]interface{}{"nested": "value"},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		require.NotPanics(t, func() {
+			// No usable string field, so an error is expected, but never a panic.
+			_, err := generateTraceID(c.fp)
+			require.Error(t, err, c.msg)
+		}, c.msg)
+	}
+}
+
+// TestGenerateTraceIDFallsBackOnNonStringField ensures a non-string value for one
+// field does not prevent a valid trace ID from being built from another field.
+func TestGenerateTraceIDFallsBackOnNonStringField(t *testing.T) {
+	fp := types.FalcoPayload{
+		OutputFields: map[string]interface{}{
+			"container.id": json.Number("42"), // non-string, must be ignored
+			"evt.hostname": "localhost",       // valid, must be used
+		},
+	}
+	require.NotPanics(t, func() {
+		traceID, err := generateTraceID(fp)
+		require.NoError(t, err)
+		// Same hash as the "Payload with Hostname" case above.
+		require.Equal(t, "b96c8fbfe005d268653aef8210412f0a", traceID.String())
+	})
 }

--- a/outputs/spyderbat.go
+++ b/outputs/spyderbat.go
@@ -147,7 +147,11 @@ func newSpyderbatPayload(falcopayload types.FalcoPayload) (spyderbatPayload, err
 		errStr := fmt.Sprintf("evt.time is nil for rule %s", falcopayload.Rule)
 		return spyderbatPayload{}, errors.New(errStr)
 	}
-	jsonTime, err := timeStr.(json.Number).Int64()
+	timeNum, ok := timeStr.(json.Number)
+	if !ok {
+		return spyderbatPayload{}, fmt.Errorf("evt.time is not a number for rule %s", falcopayload.Rule)
+	}
+	jsonTime, err := timeNum.Int64()
 	if err != nil {
 		return spyderbatPayload{}, err
 	}
@@ -158,7 +162,11 @@ func newSpyderbatPayload(falcopayload types.FalcoPayload) (spyderbatPayload, err
 		errStr := fmt.Sprintf("proc.pid is nil for rule %s", falcopayload.Rule)
 		return spyderbatPayload{}, errors.New(errStr)
 	}
-	pid, err := pidStr.(json.Number).Int64()
+	pidNum, ok := pidStr.(json.Number)
+	if !ok {
+		return spyderbatPayload{}, fmt.Errorf("proc.pid is not a number for rule %s", falcopayload.Rule)
+	}
+	pid, err := pidNum.Int64()
 	if err != nil {
 		return spyderbatPayload{}, err
 	}
@@ -169,8 +177,8 @@ func newSpyderbatPayload(falcopayload types.FalcoPayload) (spyderbatPayload, err
 	if len(args) > 2 {
 		message = args[2:]
 	}
-	arguments := falcopayload.OutputFields["proc.cmdline"].(string)
-	container := falcopayload.OutputFields["container.id"].(string)
+	arguments, _ := falcopayload.OutputFields["proc.cmdline"].(string)
+	container, _ := falcopayload.OutputFields["container.id"].(string)
 
 	return spyderbatPayload{
 		Schema:        Schema,


### PR DESCRIPTION
…nd Spyderbat outputs

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

/area tests

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Some outputs build their payload directly from `output_fields` values using single-return type assertions (e.g. `v.(string)`, `v.(json.Number)`). Those values are not guaranteed to be of the asserted type, so a payload carrying a value of the wrong type in one of those fields makes the assertion panic. Since the outputs run in their own goroutines launched by `forwardEvent`, the panic is not recovered and brings down the whole process.

This affects:
- the OTLP Traces output - `generateTraceID` asserts `k8s.ns.name`, `k8s.pod.name`, `container.id` and `evt.hostname` as `string`
- the Spyderbat output - `newSpyderbatPayload` asserts `evt.time`/`proc.pid` as `json.Number` and `proc.cmdline`/`container.id` as `string`

This PR:
- switches those assertions to the comma-ok form, so a value of the wrong type is ignored (or returns an error, for Spyderbat's numeric fields) instead of panicking
- adds a `safeGo` helper that wraps each output goroutine in `forwardEvent` with a `recover()`, as a defense-in-depth backstop so a single misbehaving output can never crash the process
- adds regression tests for `generateTraceID` with non-string fields

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

---

## Credit

Reported responsibly by [Geo](https://github.com/geo-chen) via the `cncf-falco-maintainers` security mailing list.
