### PR TITLE
fix(smtp): emit an RFC 5322-compliant Date header

### DIFF
--- a/outputs/smtp.go
+++ b/outputs/smtp.go
@@ -22,7 +22,7 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
-const rfc2822 = "Mon Jan 02 15:04:05 -0700 2006"
+const rfc2822 = "Mon, 02 Jan 2006 15:04:05 -0700"
 
 // SMTPPayload is payload for SMTP Output
 type SMTPPayload struct {

--- a/outputs/smtp_test.go
+++ b/outputs/smtp_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package outputs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falcosidekick/types"
+)
+
+// The Date header must be RFC 5322 compliant; otherwise receivers that normalize a
+// malformed Date on inbound (e.g. Microsoft 365) rewrite it and break the DKIM
+// signature, since Date is a signed header.
+func TestNewSMTPPayloadDateHeaderIsRFC5322(t *testing.T) {
+	var f types.FalcoPayload
+	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+
+	config := &types.Configuration{}
+	config.SMTP.From = "falco@localhost"
+	config.SMTP.To = "alerts@localhost"
+	config.SMTP.OutputFormat = Text
+
+	payload := newSMTPPayload(f, config)
+
+	// falcoTestInput time is 2001-01-01T01:10:00Z (a Monday) -> RFC 5322 / time.RFC1123Z form.
+	require.Contains(t, payload.Body, "Date: Mon, 01 Jan 2001 01:10:00 +0000\n")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area outputs

/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The SMTP output's `Date` header used a non–RFC 5322 layout (`"Mon Jan 02 15:04:05 -0700 2006"`), producing e.g. `Wed Jun 11 06:36:53 +0000 2026` instead of `Wed, 11 Jun 2026 06:36:53 +0000`. This trips SpamAssassin's `INVALID_DATE` and, because `Date` is a DKIM-signed header, breaks DKIM at receivers that normalize a malformed Date on inbound (e.g. Microsoft 365) → `dkim=fail` / `dmarc=fail`. Switches the layout to `"Mon, 02 Jan 2006 15:04:05 -0700"` (= `time.RFC1123Z`) and adds a regression test.


**Which issue(s) this PR fixes**:



<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1381 

**Special notes for your reviewer**:

Same timestamp, before (current) vs after (this PR):

```
Date: Wed Jun 11 06:36:53 +0000 2026     # before — not RFC 5322
Date: Wed, 11 Jun 2026 06:36:53 +0000    # after  — RFC 5322 / time.RFC1123Z
```

Verified end-to-end against a Microsoft 365 mailbox via an authenticated Brevo relay: before → `dkim=fail`/`dmarc=fail`, a "via <relay>" tag, and SpamAssassin `INVALID_DATE`; after → `dkim=pass`/`dmarc=pass`, no "via", `INVALID_DATE` gone. mail-tester confirmed the DKIM signature itself was always valid — the receiver was rewriting the malformed Date.

Before:

<img width="2315" height="1118" alt="Screenshot 2026-06-11 213434" src="https://github.com/user-attachments/assets/f984d5b1-3b89-463c-932d-c36fa8c85aea" />

After:

<img width="2315" height="1129" alt="image" src="https://github.com/user-attachments/assets/175199c1-7c52-4c36-ae5e-41cbbc9dc0fc" />

Note that after the fix, DKIM validation passes (date format is expected), so the `via ...` was removed. Expected.