### PR TITLE
fix(dynatrace): prevent panic on non-string output_fields

### DIFF
--- a/outputs/dynatrace.go
+++ b/outputs/dynatrace.go
@@ -3,9 +3,9 @@
 package outputs
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -79,21 +79,35 @@ func newDynatracePayload(falcopayload types.FalcoPayload) dtPayload {
 
 			switch fcKey {
 			case "container.id":
-				message.ContainerId = val.(string)
+				if s, ok := val.(string); ok {
+					message.ContainerId = s
+				}
 			case "container.name":
-				message.ContainerName = val.(string)
+				if s, ok := val.(string); ok {
+					message.ContainerName = s
+				}
 			case "container.image":
-				message.ContainerImageName = val.(string)
+				if s, ok := val.(string); ok {
+					message.ContainerImageName = s
+				}
 			case "k8s.ns.name", "ka.target.namespace":
-				message.K8sNamespaceName = val.(string)
+				if s, ok := val.(string); ok {
+					message.K8sNamespaceName = s
+				}
 			case "k8s.pod.name":
-				message.K8sPodName = val.(string)
+				if s, ok := val.(string); ok {
+					message.K8sPodName = s
+				}
 			case "k8s.pod.id":
-				message.K8sPodUid = val.(string)
+				if s, ok := val.(string); ok {
+					message.K8sPodUid = s
+				}
 			case "proc.name":
-				message.ProcessExecutableName = val.(string)
+				if s, ok := val.(string); ok {
+					message.ProcessExecutableName = s
+				}
 			case "span.id":
-				message.SpanId = strconv.Itoa(val.(int))
+				message.SpanId = fmt.Sprintf("%v", val)
 			default:
 				continue
 			}

--- a/outputs/dynatrace_test.go
+++ b/outputs/dynatrace_test.go
@@ -4,7 +4,7 @@ package outputs
 
 import (
 	"encoding/json"
-	"strconv"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -82,7 +82,7 @@ func TestNewDynatracePayloadWithExtraOutputFields(t *testing.T) {
 				K8sNamespaceName:      K8sNamespaceName,
 				K8sPodName:            K8sPodName,
 				ProcessExecutableName: ProcessExecutableName,
-				SpanId:                strconv.Itoa(SpanId),
+				SpanId:                fmt.Sprintf("%v", SpanId),
 				MitreTactic:           MitreTactic,
 				MitreTechnique:        MitreTechnique,
 			},
@@ -105,4 +105,32 @@ func TestNewDynatracePayloadWithExtraOutputFields(t *testing.T) {
 
 	output := newDynatracePayload(f)
 	require.Equal(t, output, expectedOutput)
+}
+
+func TestNewDynatracePayloadWithNonStringOutputFields(t *testing.T) {
+	var f types.FalcoPayload
+	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+
+	// output_fields values are not guaranteed to be strings. Feed wrong types
+	// into the fields that map to semantic attributes and make sure building
+	// the payload does not panic.
+	f.OutputFields["container.id"] = 12345
+	f.OutputFields["container.name"] = true
+	f.OutputFields["k8s.ns.name"] = float64(42)
+	f.OutputFields["proc.name"] = []string{"unexpected"}
+	f.OutputFields["span.id"] = false
+
+	var output dtPayload
+	require.NotPanics(t, func() {
+		output = newDynatracePayload(f)
+	})
+
+	msg := output.Payload[0]
+	// non-string values are ignored rather than crashing the process
+	require.Empty(t, msg.ContainerId)
+	require.Empty(t, msg.ContainerName)
+	require.Empty(t, msg.K8sNamespaceName)
+	require.Empty(t, msg.ProcessExecutableName)
+	// span.id is rendered with a type-agnostic format
+	require.Equal(t, "false", msg.SpanId)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs
/area tests

**What this PR does / why we need it**:

`newDynatracePayload` reads several `output_fields` values with single-return type assertions (`val.(string)` for `container.id`, `container.name`, `container.image`, `k8s.ns.name`, `k8s.pod.name`, `k8s.pod.id`, `proc.name`) and runs `strconv.Itoa(val.(int))` for `span.id`. Those values are not guaranteed to be of the asserted type, so a payload carrying a value of the wrong type in one of those fields makes the assertion panic. Because the output runs in its own goroutine launched by `forwardEvent`, the panic is not recovered and brings the whole process down.

This is the same class of bug that was fixed for the OTLP Traces and Spyderbat outputs in #1379; the Dynatrace output was not covered there.

This PR:
- switches the `string` mappings to the comma-ok form, so a value of the wrong type is skipped instead of panicking
- renders `span.id` with `fmt.Sprintf("%v", val)` so a non-int value no longer panics (a numeric `span.id` still formats the same way `strconv.Itoa` did)
- drops the now-unused `strconv` import and adds `fmt`
- adds a regression test feeding non-string values (int, bool, float64, slice) into those fields and asserting the payload builds without panicking

To reproduce on the current code, send an event whose `output_fields` carries a non-string value for one of the mapped keys, for example `container.id` as a number; `newDynatracePayload` panics with `interface conversion: interface {} is int, not string`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

`go test ./outputs/... -run Dynatrace`, `go build ./...` and `go vet ./outputs/...` are all green.
