### PR TITLE
Handle `CheckCert` correctly and add `TLS` field for OTLP outputs

### DIFF
--- a/config.go
+++ b/config.go
@@ -605,6 +605,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("OTLP.Traces.Timeout", 10000)
 	v.SetDefault("OTLP.Traces.Synced", false)
 	v.SetDefault("OTLP.Traces.MinimumPriority", "")
+	v.SetDefault("OTLP.Traces.TLS", false)
 	v.SetDefault("OTLP.Traces.CheckCert", true)
 	// NB: Unfortunately falco events don't provide endtime, artificially set
 	// it to 1000ms by default, override-able via OTLP_DURATION environment variable.
@@ -619,6 +620,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("OTLP.Logs.Headers", "")
 	v.SetDefault("OTLP.Logs.Timeout", 10000)
 	v.SetDefault("OTLP.Logs.MinimumPriority", "")
+	v.SetDefault("OTLP.Logs.TLS", false)
 	v.SetDefault("OTLP.Logs.CheckCert", true)
 
 	v.SetDefault("OTLP.Metrics.Endpoint", "")
@@ -628,6 +630,7 @@ func getConfig() *types.Configuration {
 	v.SetDefault("OTLP.Metrics.Headers", "")
 	v.SetDefault("OTLP.Metrics.Timeout", 10000)
 	v.SetDefault("OTLP.Metrics.MinimumPriority", "")
+	v.SetDefault("OTLP.Metrics.TLS", false)
 	v.SetDefault("OTLP.Metrics.CheckCert", true)
 	v.SetDefault("OTLP.Metrics.ExtraAttributes", "")
 

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -558,7 +558,8 @@ otlp:
       # OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: 10000
       # OTEL_EXPORTER_OTLP_TIMEOUT: 10000
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-    # checkcert: true # Set if you want to skip TLS certificate validation (default: true)
+    # tls: false # Use TLS for the connection (default: false)
+    # checkcert: true # Set to false to skip TLS certificate validation (only when tls is true) (default: true)
   logs:
     # endpoint: "" # OTLP endpoint in the form of http(s)://{domain or ip}:4318(/v1/logs), if not empty, OTLP Traces output is enabled
     # protocol: "" # OTLP protocol http/json, http/protobuf, grpc (default: "" which uses SDK default: http/json)
@@ -568,7 +569,8 @@ otlp:
       # OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: 10000
       # OTEL_EXPORTER_OTLP_TIMEOUT: 10000
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-    # checkcert: true # Set if you want to skip TLS certificate validation (default: true)
+    # tls: false # Use TLS for the connection (default: false)
+    # checkcert: true # Set to false to skip TLS certificate validation (only when tls is true) (default: true)
   metrics:
     # endpoint: "" # OTLP endpoint, typically in the form http(s)://{domain or ip}:4318(/v1/metrics), if not empty, OTLP Metrics output is enabled
     # protocol: "" # OTLP transport protocol to be used for metrics data; it can be "grpc" or "http/protobuf" (default: "grpc")
@@ -578,7 +580,8 @@ otlp:
       # OTEL_EXPORTER_OTLP_METRICS_TIMEOUT: 10000
       # OTEL_EXPORTER_OTLP_TIMEOUT: 10000
     # minimumpriority: "" # Minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default: "")
-    # checkcert: true # Set to false if you want to skip TLS certificate validation (only with https) (default: true)
+    # tls: false # Use TLS for the connection (default: false)
+    # checkcert: true # Set to false to skip TLS certificate validation (only when tls is true) (default: true)
     # extraattributes: "" # Comma-separated list of fields to use as labels additionally to source, priority, rule, hostname, tags, k8s_ns_name, k8s_pod_name and custom_fields
 
 talon:

--- a/docs/outputs/otlp_logs.md
+++ b/docs/outputs/otlp_logs.md
@@ -21,12 +21,20 @@
 | `otlp.logs.headers`         | `OTLP_LOGS_HEADERS`         |                            | List of headers to apply to all outgoing logs in the form of "some-key=some-value,other-key=other-value"                            |
 | `otlp.logs.synced`          | `OTLP_LOGS_SYNCED`          | `false`                    | Set to `true` if you want logs to be sent synchronously                                                                             |
 | `otlp.logs.minimumpriority` | `OTLP_LOGS_MINIMUMPRIORITY` | `""` (=`debug`)            | minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
-| `otlp.logs.checkcert`       | `OTLP_LOGS_CHECKCERT`       | `false`                    | Set if you want to skip TLS certificate validation                                                                                  |
+| `otlp.logs.tls`             | `OTLP_LOGS_TLS`             | `false`                    | Use TLS for the connection (default: false)                                                                                         |
+| `otlp.logs.checkcert`       | `OTLP_LOGS_CHECKCERT`       | `true`                     | Set to `false` to skip TLS certificate validation (only when `tls` is `true`)                                                       |
 | `otlp.logs.duration`        | `OTLP_LOGS_DURATION`        | `1000`                     | Artificial span duration in milliseconds (as Falco doesn't provide an ending timestamp)                                             |
 | `otlp.logs.extraenvvars`    | `OTLP_LOGS_EXTRAENVVARS`    |                            | Extra env vars (override the other settings)                                                                                        |
 
 > [!NOTE]
 For the extra Env Vars values see [standard `OTEL_*` environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+
+> [!NOTE]
+> TLS behavior depends on the combination of `tls` and `checkcert`:
+> - `tls: false` + `checkcert: true` (both defaults) — TLS with full certificate validation (kept for backward compatibility)
+> - `tls: false` + `checkcert: false` — plaintext, no TLS
+> - `tls: true` + `checkcert: true` — TLS with full certificate validation
+> - `tls: true` + `checkcert: false` — TLS without certificate validation
 
 ## Example of config.yaml
 
@@ -41,7 +49,8 @@ otlp:
       # OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: 10000
       # OTEL_EXPORTER_OTLP_TIMEOUT: 10000
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-    # checkcert: true # Set if you want to skip TLS certificate validation (default: true)
+    # tls: false # Use TLS for the connection (default: false)
+    # checkcert: true # Set to false to skip TLS certificate validation (only when tls is true) (default: true)
 ```
 
 ## Additional info

--- a/docs/outputs/otlp_metrics.md
+++ b/docs/outputs/otlp_metrics.md
@@ -25,11 +25,19 @@
 | `otlp.metrics.headers`         | `OTLP_METRICS_HEADERS`         | `""`                       | List of headers to apply to all outgoing metrics in the form of `some-key=some-value,other-key=other-value`                                         |
 | `otlp.metrics.extraenvvars`    | `OTLP_METRICS_EXTRAENVVARS`    | `""`                       | Extra env vars (override the other settings)                                                                                                        |
 | `otlp.metrics.minimumpriority` | `OTLP_METRICS_MINIMUMPRIORITY` | `""` (=`debug`)            | Minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""`                 |
-| `otlp.metrics.checkcert`       | `OTLP_METRICS_CHECKCERT`       | `true`                     | Set to false if you want to skip TLS certificate validation (only with https)                                                                       |
+| `otlp.metrics.tls`             | `OTLP_METRICS_TLS`             | `false`                    | Use TLS for the connection (default: false)                                                                                                         |
+| `otlp.metrics.checkcert`       | `OTLP_METRICS_CHECKCERT`       | `true`                     | Set to `false` to skip TLS certificate validation (only when `tls` is `true`)                                                                       |
 | `otlp.metrics.extraattributes` | `OTLP_METRICS_EXTRAATTRIBUTES` | `""`                       | Comma-separated list of fields to use as labels additionally to source, priority, rule, hostname, tags, k8s_ns_name, k8s_pod_name and custom_fields |
 
 > [!NOTE]
 For the extra Env Vars values see [standard `OTEL_*` environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+
+> [!NOTE]
+> TLS behavior depends on the combination of `tls` and `checkcert`:
+> - `tls: false` + `checkcert: true` (both defaults) — TLS with full certificate validation (kept for backward compatibility)
+> - `tls: false` + `checkcert: false` — plaintext, no TLS
+> - `tls: true` + `checkcert: true` — TLS with full certificate validation
+> - `tls: true` + `checkcert: false` — TLS without certificate validation
 
 > [!WARNING]
 If you use `grpc`, the endpoint format must be `http(s)://{domain or ip}:4318`
@@ -48,7 +56,8 @@ otlp:
       # OTEL_EXPORTER_OTLP_METRICS_TIMEOUT: 10000
       # OTEL_EXPORTER_OTLP_TIMEOUT: 10000
     # minimumpriority: "" # Minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default: "")
-    # checkcert: true # Set to false if you want to skip TLS certificate validation (only with https) (default: true)
+    # tls: false # Use TLS for the connection (default: false)
+    # checkcert: true # Set to false to skip TLS certificate validation (only when tls is true) (default: true)
     # extraattributes: "" # Comma-separated list of fields to use as labels additionally to source, priority, rule, hostname, tags, k8s_ns_name, k8s_pod_name and custom_fields
 ```
 

--- a/docs/outputs/otlp_traces.md
+++ b/docs/outputs/otlp_traces.md
@@ -25,12 +25,20 @@
 | `otlp.traces.headers`         | `OTLP_TRACES_HEADERS`         |                            | List of headers to apply to all outgoing traces in the form of "some-key=some-value,other-key=other-value"                          |
 | `otlp.traces.synced`          | `OTLP_TRACES_SYNCED`          | `false`                    | Set to `true` if you want traces to be sent synchronously                                                                           |
 | `otlp.traces.minimumpriority` | `OTLP_TRACES_MINIMUMPRIORITY` | `""` (=`debug`)            | minimum priority of event for using this output, order is `emergency,alert,critical,error,warning,notice,informational,debug or ""` |
-| `otlp.traces.checkcert`       | `OTLP_TRACES_CHECKCERT`       | `false`                    | Set if you want to skip TLS certificate validation                                                                                  |
+| `otlp.traces.tls`             | `OTLP_TRACES_TLS`             | `false`                    | Use TLS for the connection (default: false)                                                                                         |
+| `otlp.traces.checkcert`       | `OTLP_TRACES_CHECKCERT`       | `true`                     | Set to `false` to skip TLS certificate validation (only when `tls` is `true`)                                                       |
 | `otlp.traces.duration`        | `OTLP_TRACES_DURATION`        | `1000`                     | Artificial span duration in milliseconds (as Falco doesn't provide an ending timestamp)                                             |
 | `otlp.traces.extraenvvars`    | `OTLP_TRACES_EXTRAENVVARS`    |                            | Extra env vars (override the other settings)                                                                                        |
 
 > [!NOTE]
 For the extra Env Vars values see [standard `OTEL_*` environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+
+> [!NOTE]
+> TLS behavior depends on the combination of `tls` and `checkcert`:
+> - `tls: false` + `checkcert: true` (both defaults) — TLS with full certificate validation (kept for backward compatibility)
+> - `tls: false` + `checkcert: false` — plaintext, no TLS
+> - `tls: true` + `checkcert: true` — TLS with full certificate validation
+> - `tls: true` + `checkcert: false` — TLS without certificate validation
 
 > [!WARNING]
 If you use `grpc`, the endpoint format must be `http(s)://{domain or ip}:4318`
@@ -51,7 +59,8 @@ otlp:
       # OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: 10000
       # OTEL_EXPORTER_OTLP_TIMEOUT: 10000
     # minimumpriority: "" # minimum priority of event for using this output, order is emergency|alert|critical|error|warning|notice|informational|debug or "" (default)
-    # checkcert: true # Set if you want to skip TLS certificate validation (default: true)
+    # tls: false # Use TLS for the connection (default: false)
+    # checkcert: true # Set to false to skip TLS certificate validation (only when tls is true) (default: true)
 ```
 
 ## Additional info

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/pkg/utils/tls.go
+++ b/internal/pkg/utils/tls.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package utils
+
+import "crypto/tls"
+
+func InsecureSkipVerifyTLSConfig() *tls.Config {
+	return &tls.Config{InsecureSkipVerify: true}
+}

--- a/internal/pkg/utils/tls.go
+++ b/internal/pkg/utils/tls.go
@@ -5,5 +5,5 @@ package utils
 import "crypto/tls"
 
 func InsecureSkipVerifyTLSConfig() *tls.Config {
-	return &tls.Config{InsecureSkipVerify: true}
+	return &tls.Config{InsecureSkipVerify: true} // #nosec G402 This is only set as a result of explicit configuration
 }

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -519,9 +519,7 @@ func (c *Client) configureTransport() (*http.Transport, error) {
 	} else {
 		// With MutualTLS enabled, the check cert flag is ignored
 		if !c.cfg.CheckCert {
-			customTransport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify: true, // #nosec G402 This is only set as a result of explicit configuration
-			}
+			customTransport.TLSClientConfig = utils.InsecureSkipVerifyTLSConfig()
 		}
 	}
 	return customTransport, nil

--- a/outputs/logstash.go
+++ b/outputs/logstash.go
@@ -92,9 +92,7 @@ func NewLogstashClient(config *types.Configuration, stats *types.Statistics, pro
 	} else {
 		// The check cert flag and mutual tls are mutually exclusive
 		if !config.Logstash.CheckCert {
-			tlsCfg = &tls.Config{
-				InsecureSkipVerify: true, // #nosec G402 This is only set as a result of explicit configuration
-			}
+			tlsCfg = utils.InsecureSkipVerifyTLSConfig()
 		}
 	}
 

--- a/outputs/mqtt.go
+++ b/outputs/mqtt.go
@@ -3,7 +3,6 @@
 package outputs
 
 import (
-	"crypto/tls"
 	"fmt"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -28,9 +27,7 @@ func NewMQTTClient(config *types.Configuration, stats *types.Statistics, promSta
 		options.Password = config.MQTT.Password
 	}
 	if !config.MQTT.CheckCert {
-		options.TLSConfig = &tls.Config{
-			InsecureSkipVerify: true, // #nosec G402 This is only set as a result of explicit configuration
-		}
+		options.TLSConfig = utils.InsecureSkipVerifyTLSConfig()
 	}
 	options.OnConnectionLost = func(client mqtt.Client, err error) {
 		utils.Log(utils.ErrorLvl, "MQTT", fmt.Sprintf("Connection lost: %v", err))

--- a/outputs/otlp_logs.go
+++ b/outputs/otlp_logs.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"
 	otlpmetrics "github.com/falcosecurity/falcosidekick/outputs/otlp_metrics"
@@ -81,14 +82,14 @@ func OTLPLogsInit(ctx context.Context, config *types.Configuration) (*sdklog.Log
 	switch config.OTLP.Logs.Protocol {
 	case GRPC:
 		opts := []otlploggrpc.Option{}
-		if !config.OTLP.Traces.CheckCert {
-			opts = append(opts, otlploggrpc.WithInsecure())
+		if !config.OTLP.Logs.CheckCert {
+			opts = append(opts, otlploggrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
 		}
 		exporter, err = otlploggrpc.New(ctx, opts...)
 	default:
 		opts := []otlploghttp.Option{}
-		if !config.OTLP.Traces.CheckCert {
-			opts = append(opts, otlploghttp.WithInsecure())
+		if !config.OTLP.Logs.CheckCert {
+			opts = append(opts, otlploghttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
 		}
 		exporter, err = otlploghttp.New(ctx, opts...)
 	}

--- a/outputs/otlp_logs.go
+++ b/outputs/otlp_logs.go
@@ -83,13 +83,21 @@ func OTLPLogsInit(ctx context.Context, config *types.Configuration) (*sdklog.Log
 	case GRPC:
 		opts := []otlploggrpc.Option{}
 		if !config.OTLP.Logs.CheckCert {
-			opts = append(opts, otlploggrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
+			if config.OTLP.Logs.TLS {
+				opts = append(opts, otlploggrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
+			} else {
+				opts = append(opts, otlploggrpc.WithInsecure())
+			}
 		}
 		exporter, err = otlploggrpc.New(ctx, opts...)
 	default:
 		opts := []otlploghttp.Option{}
 		if !config.OTLP.Logs.CheckCert {
-			opts = append(opts, otlploghttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
+			if config.OTLP.Logs.TLS {
+				opts = append(opts, otlploghttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
+			} else {
+				opts = append(opts, otlploghttp.WithInsecure())
+			}
 		}
 		exporter, err = otlploghttp.New(ctx, opts...)
 	}

--- a/outputs/otlp_metrics/otlp_metrics.go
+++ b/outputs/otlp_metrics/otlp_metrics.go
@@ -34,6 +34,7 @@ type Config struct {
 	Timeout             int64
 	Headers             string
 	ExtraEnvVars        map[string]string
+	TLS                 bool
 	CheckCert           bool
 	MinimumPriority     string
 	ExtraAttributes     string
@@ -149,13 +150,21 @@ func initMeterProvider(ctx context.Context, config *Config) (func(context.Contex
 	case "grpc":
 		opts := []otlpmetricgrpc.Option{}
 		if !config.CheckCert {
-			opts = append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
+			if config.TLS {
+				opts = append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
+			} else {
+				opts = append(opts, otlpmetricgrpc.WithInsecure())
+			}
 		}
 		exporter, err = otlpmetricgrpc.New(ctx, opts...)
 	default:
 		opts := []otlpmetrichttp.Option{}
 		if !config.CheckCert {
-			opts = append(opts, otlpmetrichttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
+			if config.TLS {
+				opts = append(opts, otlpmetrichttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
+			} else {
+				opts = append(opts, otlpmetrichttp.WithInsecure())
+			}
 		}
 		exporter, err = otlpmetrichttp.New(ctx, opts...)
 	}

--- a/outputs/otlp_metrics/otlp_metrics.go
+++ b/outputs/otlp_metrics/otlp_metrics.go
@@ -14,6 +14,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.23.1"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"
 )
@@ -148,13 +149,13 @@ func initMeterProvider(ctx context.Context, config *Config) (func(context.Contex
 	case "grpc":
 		opts := []otlpmetricgrpc.Option{}
 		if !config.CheckCert {
-			opts = append(opts, otlpmetricgrpc.WithInsecure())
+			opts = append(opts, otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
 		}
 		exporter, err = otlpmetricgrpc.New(ctx, opts...)
 	default:
 		opts := []otlpmetrichttp.Option{}
 		if !config.CheckCert {
-			opts = append(opts, otlpmetrichttp.WithInsecure())
+			opts = append(opts, otlpmetrichttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
 		}
 		exporter, err = otlpmetrichttp.New(ctx, opts...)
 	}

--- a/outputs/otlp_traces_init.go
+++ b/outputs/otlp_traces_init.go
@@ -40,13 +40,21 @@ func installTracesExportPipeline(config *types.Configuration, ctx context.Contex
 	case GRPC:
 		opts := []otlptracegrpc.Option{}
 		if !config.OTLP.Traces.CheckCert {
-			opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
+			if config.OTLP.Traces.TLS {
+				opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
+			} else {
+				opts = append(opts, otlptracegrpc.WithInsecure())
+			}
 		}
 		exporter, err = otlptracegrpc.New(ctx, opts...)
 	default:
 		opts := []otlptracehttp.Option{}
 		if !config.OTLP.Traces.CheckCert {
-			opts = append(opts, otlptracehttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
+			if config.OTLP.Traces.TLS {
+				opts = append(opts, otlptracehttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
+			} else {
+				opts = append(opts, otlptracehttp.WithInsecure())
+			}
 		}
 		exporter, err = otlptracehttp.New(ctx, opts...)
 	}

--- a/outputs/otlp_traces_init.go
+++ b/outputs/otlp_traces_init.go
@@ -14,6 +14,7 @@ import (
 	otelresource "go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.23.1"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"
 	"github.com/falcosecurity/falcosidekick/types"
@@ -39,13 +40,13 @@ func installTracesExportPipeline(config *types.Configuration, ctx context.Contex
 	case GRPC:
 		opts := []otlptracegrpc.Option{}
 		if !config.OTLP.Traces.CheckCert {
-			opts = append(opts, otlptracegrpc.WithInsecure())
+			opts = append(opts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(utils.InsecureSkipVerifyTLSConfig())))
 		}
 		exporter, err = otlptracegrpc.New(ctx, opts...)
 	default:
 		opts := []otlptracehttp.Option{}
 		if !config.OTLP.Traces.CheckCert {
-			opts = append(opts, otlptracehttp.WithInsecure())
+			opts = append(opts, otlptracehttp.WithTLSClientConfig(utils.InsecureSkipVerifyTLSConfig()))
 		}
 		exporter, err = otlptracehttp.New(ctx, opts...)
 	}

--- a/outputs/redis.go
+++ b/outputs/redis.go
@@ -66,9 +66,7 @@ func NewRedisClient(config *types.Configuration, stats *types.Statistics, promSt
 		tlsCfg.RootCAs.AppendCertsFromPEM(caCert)
 	} else if config.Redis.TLS {
 		if !config.Redis.CheckCert {
-			tlsCfg = &tls.Config{
-				InsecureSkipVerify: true, // #nosec G402 This is only set as a result of explicit configuration
-			}
+			tlsCfg = utils.InsecureSkipVerifyTLSConfig()
 		} else {
 			pool, err := x509.SystemCertPool()
 			if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -832,11 +832,12 @@ type OTLPTraces struct {
 	Duration        int64
 	Synced          bool
 	ExtraEnvVars    map[string]string
+	TLS             bool
 	CheckCert       bool
 	MinimumPriority string
 }
 
-// OTLPLogs represents config parameters for OTLP Traces
+// OTLPLogs represents config parameters for OTLP Logs
 type OTLPLogs struct {
 	Endpoint        string
 	Protocol        string
@@ -844,6 +845,7 @@ type OTLPLogs struct {
 	Synced          bool
 	Headers         string
 	ExtraEnvVars    map[string]string
+	TLS             bool
 	CheckCert       bool
 	MinimumPriority string
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
The OTLP outputs (logs, traces, metrics) have two bugs related to TLS configuration, which were firstly described in https://github.com/falcosecurity/falcosidekick/pull/1287:

1. `CheckCert: false` incorrectly calls `WithInsecure()`, which results in plaintext communication instead of TLS without certificate validation.
2. The Logs output checks `config.OTLP.Traces.CheckCert` instead of `config.OTLP.Logs.CheckCert`.

This PR fixes both issues and adds a `TLS` boolean field (default: `false`) to all OTLP outputs. To get TLS without certificate validation, users must now set `TLS: true` and `CheckCert: false`. This preserves backward compatibility, existing users who had `CheckCert: false` (which gave them plaintext due to the bug) continue to get plaintext, and users with `CheckCert: true` (default) continue to get TLS with validation.

It also extracts a shared `InsecureSkipVerifyTLSConfig()` helper used by all outputs that support skipping certificate validation.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Continues to work from #1287

**Special notes for your reviewer**:
The new `TLS` field defaults to `false`. When `CheckCert` is `true` (default), the `TLS` field has no effect(to be backwards compatible). The `TLS` field only has an effect when `CheckCert: false`. It determines whether to use plaintext (`TLS: false`) or TLS without certificate validation (`TLS: true`).

Note: the OTLP Logs output previously read `config.OTLP.Traces.CheckCert` instead of `config.OTLP.Logs.CheckCert`. Users who had `CheckCert: false` set specifically for Logs (expecting it to apply to the Logs output) were not getting the intended effect. After this fix, `OTLP.Logs.CheckCert` is now correctly used, which may change behavior for users who had different `CheckCert` values for Traces vs Logs.
