### PR TITLE
Fix race condition when multiple outputs are configured

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -310,274 +310,288 @@ func safeGo(fn func()) {
 }
 
 func forwardEvent(falcopayload types.FalcoPayload) {
+	var dispatches []func(types.FalcoPayload)
+
 	if config.Slack.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Slack.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { slackClient.SlackPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { slackClient.SlackPost(p) })
 	}
 
 	if config.Cliq.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Cliq.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { cliqClient.CliqPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { cliqClient.CliqPost(p) })
 	}
 
 	if config.Rocketchat.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Rocketchat.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { rocketchatClient.RocketchatPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { rocketchatClient.RocketchatPost(p) })
 	}
 
 	if config.Mattermost.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Mattermost.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { mattermostClient.MattermostPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { mattermostClient.MattermostPost(p) })
 	}
 
 	if config.Teams.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Teams.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { teamsClient.TeamsPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { teamsClient.TeamsPost(p) })
 	}
 
 	if config.Webex.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Webex.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { webexClient.WebexPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { webexClient.WebexPost(p) })
 	}
 
 	if config.Datadog.APIKey != "" && (falcopayload.Priority >= types.Priority(config.Datadog.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { datadogClient.DatadogPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { datadogClient.DatadogPost(p) })
 	}
 
 	if config.DatadogLogs.APIKey != "" && (falcopayload.Priority >= types.Priority(config.DatadogLogs.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { datadogLogsClient.DatadogLogsPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { datadogLogsClient.DatadogLogsPost(p) })
 	}
 
 	if config.Discord.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Discord.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { discordClient.DiscordPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { discordClient.DiscordPost(p) })
 	}
 
 	if len(config.Alertmanager.HostPort) != 0 && (falcopayload.Priority >= types.Priority(config.Alertmanager.MinimumPriority) || falcopayload.Rule == testRule) {
 		for _, i := range alertmanagerClients {
-			safeGo(func() { i.AlertmanagerPost(falcopayload) })
+			i := i
+			dispatches = append(dispatches, func(p types.FalcoPayload) { i.AlertmanagerPost(p) })
 		}
 	}
 
 	if config.Elasticsearch.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Elasticsearch.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { elasticsearchClient.ElasticsearchPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { elasticsearchClient.ElasticsearchPost(p) })
 	}
 
 	if config.Quickwit.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Quickwit.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { quickwitClient.QuickwitPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { quickwitClient.QuickwitPost(p) })
 	}
 
 	if config.Influxdb.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Influxdb.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { influxdbClient.InfluxdbPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { influxdbClient.InfluxdbPost(p) })
 	}
 
 	if config.Loki.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Loki.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { lokiClient.LokiPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { lokiClient.LokiPost(p) })
 	}
 
 	if config.SumoLogic.ReceiverURL != "" && (falcopayload.Priority >= types.Priority(config.SumoLogic.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { sumologicClient.SumoLogicPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { sumologicClient.SumoLogicPost(p) })
 	}
 
 	if config.Nats.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Nats.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { natsClient.NatsPublish(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { natsClient.NatsPublish(p) })
 	}
 
 	if config.Stan.HostPort != "" && config.Stan.ClusterID != "" && config.Stan.ClientID != "" && (falcopayload.Priority >= types.Priority(config.Stan.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { stanClient.StanPublish(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { stanClient.StanPublish(p) })
 	}
 
 	if config.AWS.Lambda.FunctionName != "" && (falcopayload.Priority >= types.Priority(config.AWS.Lambda.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.InvokeLambda(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.InvokeLambda(p) })
 	}
 
 	if config.AWS.SQS.URL != "" && (falcopayload.Priority >= types.Priority(config.AWS.SQS.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.SendMessage(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.SendMessage(p) })
 	}
 
 	if config.AWS.SNS.TopicArn != "" && (falcopayload.Priority >= types.Priority(config.AWS.SNS.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.PublishTopic(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.PublishTopic(p) })
 	}
 
 	if config.AWS.CloudWatchLogs.LogGroup != "" && (falcopayload.Priority >= types.Priority(config.AWS.CloudWatchLogs.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.SendCloudWatchLog(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.SendCloudWatchLog(p) })
 	}
 
 	if config.AWS.S3.Bucket != "" && (falcopayload.Priority >= types.Priority(config.AWS.S3.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.UploadS3(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.UploadS3(p) })
 	}
 
 	if (config.AWS.SecurityLake.Bucket != "" && config.AWS.SecurityLake.Region != "" && config.AWS.SecurityLake.AccountID != "" && config.AWS.SecurityLake.Prefix != "") && (falcopayload.Priority >= types.Priority(config.AWS.SecurityLake.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.EnqueueSecurityLake(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.EnqueueSecurityLake(p) })
 	}
 
 	if config.AWS.Kinesis.StreamName != "" && (falcopayload.Priority >= types.Priority(config.AWS.Kinesis.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { awsClient.PutRecord(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { awsClient.PutRecord(p) })
 	}
 
 	if config.SMTP.HostPort != "" && (falcopayload.Priority >= types.Priority(config.SMTP.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { smtpClient.SendMail(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { smtpClient.SendMail(p) })
 	}
 
 	if config.Opsgenie.APIKey != "" && (falcopayload.Priority >= types.Priority(config.Opsgenie.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { opsgenieClient.OpsgeniePost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { opsgenieClient.OpsgeniePost(p) })
 	}
 
 	if config.Webhook.Address != "" && (falcopayload.Priority >= types.Priority(config.Webhook.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { webhookClient.WebhookPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { webhookClient.WebhookPost(p) })
 	}
 
 	if config.Splunk.Host != "" && (falcopayload.Priority >= types.Priority(config.Splunk.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { splunkClient.Send(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { splunkClient.Send(p) })
 	}
 
 	if config.NodeRed.Address != "" && (falcopayload.Priority >= types.Priority(config.NodeRed.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { noderedClient.NodeRedPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { noderedClient.NodeRedPost(p) })
 	}
 
 	if config.CloudEvents.Address != "" && (falcopayload.Priority >= types.Priority(config.CloudEvents.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { cloudeventsClient.CloudEventsSend(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { cloudeventsClient.CloudEventsSend(p) })
 	}
 
 	if config.Azure.EventHub.Name != "" && (falcopayload.Priority >= types.Priority(config.Azure.EventHub.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { azureClient.EventHubPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { azureClient.EventHubPost(p) })
 	}
 
 	if config.GCP.PubSub.ProjectID != "" && config.GCP.PubSub.Topic != "" && (falcopayload.Priority >= types.Priority(config.GCP.PubSub.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { gcpClient.GCPPublishTopic(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { gcpClient.GCPPublishTopic(p) })
 	}
 
 	if config.GCP.CloudFunctions.Name != "" && (falcopayload.Priority >= types.Priority(config.GCP.CloudFunctions.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { gcpClient.GCPCallCloudFunction(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { gcpClient.GCPCallCloudFunction(p) })
 	}
 
 	if config.GCP.CloudRun.Endpoint != "" && (falcopayload.Priority >= types.Priority(config.GCP.CloudRun.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { gcpCloudRunClient.CloudRunFunctionPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { gcpCloudRunClient.CloudRunFunctionPost(p) })
 	}
 
 	if config.GCP.Storage.Bucket != "" && (falcopayload.Priority >= types.Priority(config.GCP.Storage.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { gcpClient.UploadGCS(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { gcpClient.UploadGCS(p) })
 	}
 
 	if config.GCP.Chronicle.Region != "" && config.GCP.Chronicle.ProjectID != "" && config.GCP.Chronicle.InstanceID != "" && gcpClient != nil && (falcopayload.Priority >= types.Priority(config.GCP.Chronicle.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { gcpClient.GCPChronicleIngest(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { gcpClient.GCPChronicleIngest(p) })
 	}
 
 	if config.Googlechat.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.Googlechat.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { googleChatClient.GooglechatPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { googleChatClient.GooglechatPost(p) })
 	}
 
 	if config.Kafka.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Kafka.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { kafkaClient.KafkaProduce(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { kafkaClient.KafkaProduce(p) })
 	}
 
 	if config.KafkaRest.Address != "" && (falcopayload.Priority >= types.Priority(config.KafkaRest.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { kafkaRestClient.KafkaRestPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { kafkaRestClient.KafkaRestPost(p) })
 	}
 
 	if config.Pagerduty.RoutingKey != "" && (falcopayload.Priority >= types.Priority(config.Pagerduty.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { pagerdutyClient.PagerdutyPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { pagerdutyClient.PagerdutyPost(p) })
 	}
 
 	if config.Kubeless.Namespace != "" && config.Kubeless.Function != "" && (falcopayload.Priority >= types.Priority(config.Kubeless.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { kubelessClient.KubelessCall(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { kubelessClient.KubelessCall(p) })
 	}
 
 	if config.Openfaas.FunctionName != "" && (falcopayload.Priority >= types.Priority(config.Openfaas.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { openfaasClient.OpenfaasCall(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { openfaasClient.OpenfaasCall(p) })
 	}
 
 	if config.Tekton.EventListener != "" && (falcopayload.Priority >= types.Priority(config.Tekton.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { tektonClient.TektonPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { tektonClient.TektonPost(p) })
 	}
 
 	if config.Rabbitmq.URL != "" && config.Rabbitmq.Queue != "" && (falcopayload.Priority >= types.Priority(config.Rabbitmq.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { rabbitmqClient.Publish(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { rabbitmqClient.Publish(p) })
 	}
 
 	if config.Wavefront.EndpointHost != "" && config.Wavefront.EndpointType != "" && (falcopayload.Priority >= types.Priority(config.Wavefront.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { wavefrontClient.WavefrontPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { wavefrontClient.WavefrontPost(p) })
 	}
 
 	if config.Grafana.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Grafana.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { grafanaClient.GrafanaPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { grafanaClient.GrafanaPost(p) })
 	}
 
 	if config.GrafanaOnCall.WebhookURL != "" && (falcopayload.Priority >= types.Priority(config.GrafanaOnCall.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { grafanaOnCallClient.GrafanaOnCallPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { grafanaOnCallClient.GrafanaOnCallPost(p) })
 	}
 
 	if config.WebUI.URL != "" {
-		safeGo(func() { webUIClient.WebUIPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { webUIClient.WebUIPost(p) })
 	}
 
 	if config.Fission.Function != "" && (falcopayload.Priority >= types.Priority(config.Fission.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { fissionClient.FissionCall(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { fissionClient.FissionCall(p) })
 	}
+
 	if config.PolicyReport.Enabled && (falcopayload.Priority >= types.Priority(config.PolicyReport.MinimumPriority)) {
 		if falcopayload.Source == syscalls || falcopayload.Source == syscall || falcopayload.Source == "k8saudit" {
-			safeGo(func() { policyReportClient.UpdateOrCreatePolicyReport(falcopayload) })
+			dispatches = append(dispatches, func(p types.FalcoPayload) { policyReportClient.UpdateOrCreatePolicyReport(p) })
 		}
 	}
 
 	if config.Yandex.S3.Bucket != "" && (falcopayload.Priority >= types.Priority(config.Yandex.S3.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { yandexClient.UploadYandexS3(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { yandexClient.UploadYandexS3(p) })
 	}
 
 	if config.Yandex.DataStreams.StreamName != "" && (falcopayload.Priority >= types.Priority(config.Yandex.DataStreams.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { yandexClient.UploadYandexDataStreams(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { yandexClient.UploadYandexDataStreams(p) })
 	}
 
 	if config.Syslog.Host != "" && (falcopayload.Priority >= types.Priority(config.Syslog.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { syslogClient.SyslogPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { syslogClient.SyslogPost(p) })
 	}
 
 	if config.MQTT.Broker != "" && (falcopayload.Priority >= types.Priority(config.MQTT.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { mqttClient.MQTTPublish(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { mqttClient.MQTTPublish(p) })
 	}
 
 	if config.Zincsearch.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Zincsearch.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { zincsearchClient.ZincsearchPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { zincsearchClient.ZincsearchPost(p) })
 	}
 
 	if config.Gotify.HostPort != "" && (falcopayload.Priority >= types.Priority(config.Gotify.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { gotifyClient.GotifyPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { gotifyClient.GotifyPost(p) })
 	}
 
 	if config.Spyderbat.OrgUID != "" && (falcopayload.Priority >= types.Priority(config.Spyderbat.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { spyderbatClient.SpyderbatPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { spyderbatClient.SpyderbatPost(p) })
 	}
 
 	if config.TimescaleDB.Host != "" && (falcopayload.Priority >= types.Priority(config.TimescaleDB.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { timescaleDBClient.TimescaleDBPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { timescaleDBClient.TimescaleDBPost(p) })
 	}
 
 	if config.Redis.Address != "" && (falcopayload.Priority >= types.Priority(config.Redis.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { redisClient.RedisPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { redisClient.RedisPost(p) })
 	}
 
 	if config.Telegram.ChatID != "" && config.Telegram.Token != "" && (falcopayload.Priority >= types.Priority(config.Telegram.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { telegramClient.TelegramPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { telegramClient.TelegramPost(p) })
 	}
 
 	if config.N8N.Address != "" && (falcopayload.Priority >= types.Priority(config.N8N.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { n8nClient.N8NPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { n8nClient.N8NPost(p) })
 	}
 
 	if config.OpenObserve.HostPort != "" && (falcopayload.Priority >= types.Priority(config.OpenObserve.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { openObserveClient.OpenObservePost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { openObserveClient.OpenObservePost(p) })
 	}
 
 	if config.Dynatrace.APIToken != "" && config.Dynatrace.APIUrl != "" && (falcopayload.Priority >= types.Priority(config.Dynatrace.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { dynatraceClient.DynatracePost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { dynatraceClient.DynatracePost(p) })
 	}
 
 	if config.OTLP.Traces.Endpoint != "" && (falcopayload.Priority >= types.Priority(config.OTLP.Traces.MinimumPriority)) && (falcopayload.Source == syscall || falcopayload.Source == syscalls) {
-		safeGo(func() { otlpTracesClient.OTLPTracesPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { otlpTracesClient.OTLPTracesPost(p) })
 	}
 
 	if config.OTLP.Logs.Endpoint != "" && (falcopayload.Priority >= types.Priority(config.OTLP.Logs.MinimumPriority)) {
-		safeGo(func() { otlpLogsClient.OTLPLogsPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { otlpLogsClient.OTLPLogsPost(p) })
 	}
 
 	if config.Talon.Address != "" && (falcopayload.Priority >= types.Priority(config.Talon.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { talonClient.TalonPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { talonClient.TalonPost(p) })
 	}
 
 	if config.Logstash.Address != "" && (falcopayload.Priority >= types.Priority(config.Logstash.MinimumPriority) || falcopayload.Rule == testRule) {
-		safeGo(func() { logstashClient.LogstashPost(falcopayload) })
+		dispatches = append(dispatches, func(p types.FalcoPayload) { logstashClient.LogstashPost(p) })
+	}
+
+	multipleOutputs := len(dispatches) > 1
+	for _, fn := range dispatches {
+		fn := fn
+		if multipleOutputs {
+			safeGo(func() { fn(falcopayload.DeepCopy()) })
+		} else {
+			safeGo(func() { fn(falcopayload) })
+		}
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -29,6 +29,23 @@ type FalcoPayload struct {
 	Hostname     string                 `json:"hostname,omitempty"`
 }
 
+// DeepCopy returns a deep copy of the FalcoPayload, duplicating the OutputFields
+// map and Tags slice so concurrent goroutines can safely read without racing.
+func (f FalcoPayload) DeepCopy() FalcoPayload {
+	c := f
+	if f.OutputFields != nil {
+		c.OutputFields = make(map[string]interface{}, len(f.OutputFields))
+		for k, v := range f.OutputFields {
+			c.OutputFields[k] = v
+		}
+	}
+	if f.Tags != nil {
+		c.Tags = make([]string, len(f.Tags))
+		copy(c.Tags, f.Tags)
+	}
+	return c
+}
+
 func (f FalcoPayload) String() string {
 	j, _ := json.Marshal(f)
 	return string(j)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area config

/area outputs

> /area tests

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

With multiple outputs (3 at the moment) and lots of events (falco-event-generator, but can also happen naturally), there are lots of panics. This PR fixes the race conditions where multiple output implementations access the same underlying map by making a deep copy if multiple outputs are configured.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #1388 

**Special notes for your reviewer**:

I have tested this fix locally that multiple outputs do work without a race condition.