### PR TITLE
build(deps): Upgrade datadog-go to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/storage v1.56.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2
-	github.com/DataDog/datadog-go v4.8.3+incompatible
+	github.com/DataDog/datadog-go/v5 v5.9.1
 	github.com/PagerDuty/go-pagerduty v1.8.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/aws/aws-sdk-go-v2 v1.43.5

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
-github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/datadog-go/v5 v5.9.1 h1:jOxw/TaxGWok8RIxbpqn2p3RzSnQr/m3Q6TgaHqqOU0=
+github.com/DataDog/datadog-go/v5 v5.9.1/go.mod h1:2SBt8zJu6r7sRQHZFMQ8oCukWTKj0ymwulmNgQzJ1JM=
 github.com/GoogleCloudPlatform/cloudsql-proxy v1.29.0/go.mod h1:spvB9eLJH9dutlbPSRmHvSXXHOwGRyeXh1jVdquA2G8=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
@@ -176,6 +176,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -829,6 +830,7 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=

--- a/main.go
+++ b/main.go
@@ -275,6 +275,7 @@ func init() {
 		if err != nil {
 			config.Elasticsearch.HostPort = ""
 		} else {
+
 			outputs.EnabledOutputs = append(outputs.EnabledOutputs, "Elasticsearch")
 		}
 	}
@@ -513,7 +514,7 @@ func init() {
 
 	if config.GCP.CloudRun.Endpoint != "" && config.GCP.CloudRun.JWT != "" {
 		var err error
-		outputName := "GCPCloudRun"
+		var outputName = "GCPCloudRun"
 
 		gcpCloudRunClient, err = outputs.NewClient(outputName, config.GCP.CloudRun.Endpoint, types.CommonConfig{}, *initClientArgs)
 
@@ -556,8 +557,8 @@ func init() {
 
 	if config.Pagerduty.RoutingKey != "" {
 		var err error
-		url := "https://events.pagerduty.com/v2/enqueue"
-		outputName := "Pagerduty"
+		var url = "https://events.pagerduty.com/v2/enqueue"
+		var outputName = "Pagerduty"
 
 		pagerdutyClient, err = outputs.NewClient(outputName, url, config.Pagerduty.CommonConfig, *initClientArgs)
 
@@ -653,7 +654,7 @@ func init() {
 
 	if config.Grafana.HostPort != "" && config.Grafana.APIKey != "" {
 		var err error
-		outputName := "Grafana"
+		var outputName = "Grafana"
 		endpointUrl := fmt.Sprintf("%s/api/annotations", config.Grafana.HostPort)
 		grafanaClient, err = outputs.NewClient(outputName, endpointUrl, config.Grafana.CommonConfig, *initClientArgs)
 		if err != nil {
@@ -666,7 +667,7 @@ func init() {
 
 	if config.GrafanaOnCall.WebhookURL != "" {
 		var err error
-		outputName := "GrafanaOnCall"
+		var outputName = "GrafanaOnCall"
 		grafanaOnCallClient, err = outputs.NewClient(outputName, config.GrafanaOnCall.WebhookURL, config.GrafanaOnCall.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.GrafanaOnCall.WebhookURL = ""
@@ -789,7 +790,7 @@ func init() {
 
 	if config.Telegram.ChatID != "" && config.Telegram.Token != "" {
 		var err error
-		urlFormat := "%s/bot%s/sendMessage"
+		var urlFormat = "%s/bot%s/sendMessage"
 
 		telegramClient, err = outputs.NewClient("Telegram", fmt.Sprintf(urlFormat, config.Telegram.Host, config.Telegram.Token), types.CommonConfig{CheckCert: config.Telegram.CheckCert}, *initClientArgs)
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/embano1/memlog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -275,7 +275,6 @@ func init() {
 		if err != nil {
 			config.Elasticsearch.HostPort = ""
 		} else {
-
 			outputs.EnabledOutputs = append(outputs.EnabledOutputs, "Elasticsearch")
 		}
 	}
@@ -514,7 +513,7 @@ func init() {
 
 	if config.GCP.CloudRun.Endpoint != "" && config.GCP.CloudRun.JWT != "" {
 		var err error
-		var outputName = "GCPCloudRun"
+		outputName := "GCPCloudRun"
 
 		gcpCloudRunClient, err = outputs.NewClient(outputName, config.GCP.CloudRun.Endpoint, types.CommonConfig{}, *initClientArgs)
 
@@ -557,8 +556,8 @@ func init() {
 
 	if config.Pagerduty.RoutingKey != "" {
 		var err error
-		var url = "https://events.pagerduty.com/v2/enqueue"
-		var outputName = "Pagerduty"
+		url := "https://events.pagerduty.com/v2/enqueue"
+		outputName := "Pagerduty"
 
 		pagerdutyClient, err = outputs.NewClient(outputName, url, config.Pagerduty.CommonConfig, *initClientArgs)
 
@@ -654,7 +653,7 @@ func init() {
 
 	if config.Grafana.HostPort != "" && config.Grafana.APIKey != "" {
 		var err error
-		var outputName = "Grafana"
+		outputName := "Grafana"
 		endpointUrl := fmt.Sprintf("%s/api/annotations", config.Grafana.HostPort)
 		grafanaClient, err = outputs.NewClient(outputName, endpointUrl, config.Grafana.CommonConfig, *initClientArgs)
 		if err != nil {
@@ -667,7 +666,7 @@ func init() {
 
 	if config.GrafanaOnCall.WebhookURL != "" {
 		var err error
-		var outputName = "GrafanaOnCall"
+		outputName := "GrafanaOnCall"
 		grafanaOnCallClient, err = outputs.NewClient(outputName, config.GrafanaOnCall.WebhookURL, config.GrafanaOnCall.CommonConfig, *initClientArgs)
 		if err != nil {
 			config.GrafanaOnCall.WebhookURL = ""
@@ -790,7 +789,7 @@ func init() {
 
 	if config.Telegram.ChatID != "" && config.Telegram.Token != "" {
 		var err error
-		var urlFormat = "%s/bot%s/sendMessage"
+		urlFormat := "%s/bot%s/sendMessage"
 
 		telegramClient, err = outputs.NewClient("Telegram", fmt.Sprintf(urlFormat, config.Telegram.Host, config.Telegram.Token), types.CommonConfig{CheckCert: config.Telegram.CheckCert}, *initClientArgs)
 

--- a/outputs/aws.go
+++ b/outputs/aws.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"

--- a/outputs/azure.go
+++ b/outputs/azure.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	azeventhubs "github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -81,26 +81,20 @@ var EnabledOutputs []string
 const DefaultContentType = "application/json; charset=utf-8"
 
 // Some common header values that may be needed in other files
-const (
-	ContentTypeHeaderKey   = "Content-Type"
-	UserAgentHeaderKey     = "User-Agent"
-	AuthorizationHeaderKey = "Authorization"
-	UserAgentHeaderValue   = "Falcosidekick"
-	Bearer                 = "Bearer"
-)
+const ContentTypeHeaderKey = "Content-Type"
+const UserAgentHeaderKey = "User-Agent"
+const AuthorizationHeaderKey = "Authorization"
+const UserAgentHeaderValue = "Falcosidekick"
+const Bearer = "Bearer"
 
 // files names are static fo the shake of helm and single docker compatibility
-const (
-	MutualTLSClientCertFilename = "/client.crt"
-	MutualTLSClientKeyFilename  = "/client.key"
-	MutualTLSCacertFilename     = "/ca.crt"
-)
+const MutualTLSClientCertFilename = "/client.crt"
+const MutualTLSClientKeyFilename = "/client.key"
+const MutualTLSCacertFilename = "/ca.crt"
 
 // HTTP Methods
-const (
-	HttpPost = "POST"
-	HttpPut  = "PUT"
-)
+const HttpPost = "POST"
+const HttpPut = "PUT"
 
 // Protocol
 const GRPC = "grpc"
@@ -388,7 +382,7 @@ func (c *Client) sendRequest(method string, payload interface{}, responseBody *s
 	go c.CountMetric("outputs", 1, []string{"output:" + strings.ToLower(c.OutputType), "status:" + strings.ToLower(http.StatusText(resp.StatusCode))})
 
 	switch resp.StatusCode {
-	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: // 200, 201, 202, 204
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: //200, 201, 202, 204
 		utils.Log(utils.InfoLvl, c.OutputType, fmt.Sprintf("%v OK (%v)", method, resp.StatusCode))
 		ot := c.OutputType
 		logResponse := ot == Kubeless || ot == Openfaas || ot == Fission

--- a/outputs/client.go
+++ b/outputs/client.go
@@ -24,7 +24,7 @@ import (
 	gcpfunctions "cloud.google.com/go/functions/apiv1"
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/storage"
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -81,20 +81,26 @@ var EnabledOutputs []string
 const DefaultContentType = "application/json; charset=utf-8"
 
 // Some common header values that may be needed in other files
-const ContentTypeHeaderKey = "Content-Type"
-const UserAgentHeaderKey = "User-Agent"
-const AuthorizationHeaderKey = "Authorization"
-const UserAgentHeaderValue = "Falcosidekick"
-const Bearer = "Bearer"
+const (
+	ContentTypeHeaderKey   = "Content-Type"
+	UserAgentHeaderKey     = "User-Agent"
+	AuthorizationHeaderKey = "Authorization"
+	UserAgentHeaderValue   = "Falcosidekick"
+	Bearer                 = "Bearer"
+)
 
 // files names are static fo the shake of helm and single docker compatibility
-const MutualTLSClientCertFilename = "/client.crt"
-const MutualTLSClientKeyFilename = "/client.key"
-const MutualTLSCacertFilename = "/ca.crt"
+const (
+	MutualTLSClientCertFilename = "/client.crt"
+	MutualTLSClientKeyFilename  = "/client.key"
+	MutualTLSCacertFilename     = "/ca.crt"
+)
 
 // HTTP Methods
-const HttpPost = "POST"
-const HttpPut = "PUT"
+const (
+	HttpPost = "POST"
+	HttpPut  = "PUT"
+)
 
 // Protocol
 const GRPC = "grpc"
@@ -382,7 +388,7 @@ func (c *Client) sendRequest(method string, payload interface{}, responseBody *s
 	go c.CountMetric("outputs", 1, []string{"output:" + strings.ToLower(c.OutputType), "status:" + strings.ToLower(http.StatusText(resp.StatusCode))})
 
 	switch resp.StatusCode {
-	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: //200, 201, 202, 204
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: // 200, 201, 202, 204
 		utils.Log(utils.InfoLvl, c.OutputType, fmt.Sprintf("%v OK (%v)", method, resp.StatusCode))
 		ot := c.OutputType
 		logResponse := ot == Kubeless || ot == Openfaas || ot == Fission

--- a/outputs/fission.go
+++ b/outputs/fission.go
@@ -21,18 +21,15 @@ import (
 )
 
 // Some constant strings to use in request headers
-const (
-	FissionEventIDKey        = "event-id"
-	FissionEventNamespaceKey = "event-namespace"
-	FissionContentType       = "application/json"
-	APIv1Namespaces          = "/api/v1/namespaces/"
-	ServicesPath             = "/services/"
-)
+const FissionEventIDKey = "event-id"
+const FissionEventNamespaceKey = "event-namespace"
+const FissionContentType = "application/json"
+const APIv1Namespaces = "/api/v1/namespaces/"
+const ServicesPath = "/services/"
 
 // NewFissionClient returns a new output.Client for accessing Kubernetes.
 func NewFissionClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	if config.Fission.KubeConfig != "" {
 		restConfig, err := clientcmd.BuildConfigFromFlags("", config.Fission.KubeConfig)
 		if err != nil {

--- a/outputs/fission.go
+++ b/outputs/fission.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/client-go/kubernetes"
@@ -21,15 +21,18 @@ import (
 )
 
 // Some constant strings to use in request headers
-const FissionEventIDKey = "event-id"
-const FissionEventNamespaceKey = "event-namespace"
-const FissionContentType = "application/json"
-const APIv1Namespaces = "/api/v1/namespaces/"
-const ServicesPath = "/services/"
+const (
+	FissionEventIDKey        = "event-id"
+	FissionEventNamespaceKey = "event-namespace"
+	FissionContentType       = "application/json"
+	APIv1Namespaces          = "/api/v1/namespaces/"
+	ServicesPath             = "/services/"
+)
 
 // NewFissionClient returns a new output.Client for accessing Kubernetes.
 func NewFissionClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	if config.Fission.KubeConfig != "" {
 		restConfig, err := clientcmd.BuildConfigFromFlags("", config.Fission.KubeConfig)
 		if err != nil {

--- a/outputs/gcp.go
+++ b/outputs/gcp.go
@@ -30,8 +30,7 @@ import (
 
 // NewGCPClient returns a new output.Client for accessing the GCP API.
 func NewGCPClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	base64decodedCredentialsData, err := base64.StdEncoding.DecodeString(config.GCP.Credentials)
 	if err != nil {
 		utils.Log(utils.ErrorLvl, "GCP", "Erroc.OutputTyper while base64-decoding GCP Credentials")

--- a/outputs/gcp.go
+++ b/outputs/gcp.go
@@ -15,7 +15,7 @@ import (
 	gcpfunctions "cloud.google.com/go/functions/apiv1"
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/storage"
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/googleapis/gax-go/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/oauth2"
@@ -30,7 +30,8 @@ import (
 
 // NewGCPClient returns a new output.Client for accessing the GCP API.
 func NewGCPClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	base64decodedCredentialsData, err := base64.StdEncoding.DecodeString(config.GCP.Credentials)
 	if err != nil {
 		utils.Log(utils.ErrorLvl, "GCP", "Erroc.OutputTyper while base64-decoding GCP Credentials")

--- a/outputs/kafka.go
+++ b/outputs/kafka.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/plain"
 	"github.com/segmentio/kafka-go/sasl/scram"
@@ -25,8 +25,8 @@ import (
 
 // NewKafkaClient returns a new output.Client for accessing the Apache Kafka.
 func NewKafkaClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	transport := &kafka.Transport{
 		Dial: (&net.Dialer{
 			Timeout:   3 * time.Second,
@@ -37,7 +37,6 @@ func NewKafkaClient(config *types.Configuration, stats *types.Statistics, promSt
 
 	if config.Kafka.TLS {
 		caCertPool, err := x509.SystemCertPool()
-
 		if err != nil {
 			utils.Log(utils.ErrorLvl, "Kafka", fmt.Sprintf("failed to initialize root CAs: %v", err))
 		}

--- a/outputs/kafka.go
+++ b/outputs/kafka.go
@@ -25,8 +25,8 @@ import (
 
 // NewKafkaClient returns a new output.Client for accessing the Apache Kafka.
 func NewKafkaClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	transport := &kafka.Transport{
 		Dial: (&net.Dialer{
 			Timeout:   3 * time.Second,
@@ -37,6 +37,7 @@ func NewKafkaClient(config *types.Configuration, stats *types.Statistics, promSt
 
 	if config.Kafka.TLS {
 		caCertPool, err := x509.SystemCertPool()
+
 		if err != nil {
 			utils.Log(utils.ErrorLvl, "Kafka", fmt.Sprintf("failed to initialize root CAs: %v", err))
 		}

--- a/outputs/kubeless.go
+++ b/outputs/kubeless.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/client-go/kubernetes"
@@ -21,16 +21,19 @@ import (
 )
 
 // Some constant strings to use in request headers
-const KubelessEventIDKey = "event-id"
-const KubelessUserAgentKey = "User-Agent"
-const KubelessEventTypeKey = "event-type"
-const KubelessEventNamespaceKey = "event-namespace"
-const KubelessEventTypeValue = "falco"
-const KubelessContentType = "application/json"
+const (
+	KubelessEventIDKey        = "event-id"
+	KubelessUserAgentKey      = "User-Agent"
+	KubelessEventTypeKey      = "event-type"
+	KubelessEventNamespaceKey = "event-namespace"
+	KubelessEventTypeValue    = "falco"
+	KubelessContentType       = "application/json"
+)
 
 // NewKubelessClient returns a new output.Client for accessing Kubernetes.
 func NewKubelessClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	if config.Kubeless.Kubeconfig != "" {
 		restConfig, err := clientcmd.BuildConfigFromFlags("", config.Kubeless.Kubeconfig)
 		if err != nil {

--- a/outputs/kubeless.go
+++ b/outputs/kubeless.go
@@ -21,19 +21,16 @@ import (
 )
 
 // Some constant strings to use in request headers
-const (
-	KubelessEventIDKey        = "event-id"
-	KubelessUserAgentKey      = "User-Agent"
-	KubelessEventTypeKey      = "event-type"
-	KubelessEventNamespaceKey = "event-namespace"
-	KubelessEventTypeValue    = "falco"
-	KubelessContentType       = "application/json"
-)
+const KubelessEventIDKey = "event-id"
+const KubelessUserAgentKey = "User-Agent"
+const KubelessEventTypeKey = "event-type"
+const KubelessEventNamespaceKey = "event-namespace"
+const KubelessEventTypeValue = "falco"
+const KubelessContentType = "application/json"
 
 // NewKubelessClient returns a new output.Client for accessing Kubernetes.
 func NewKubelessClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	if config.Kubeless.Kubeconfig != "" {
 		restConfig, err := clientcmd.BuildConfigFromFlags("", config.Kubeless.Kubeconfig)
 		if err != nil {

--- a/outputs/logstash.go
+++ b/outputs/logstash.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"
 	"github.com/falcosecurity/falcosidekick/types"
 	"github.com/telkomdev/go-stash"

--- a/outputs/mqtt.go
+++ b/outputs/mqtt.go
@@ -5,7 +5,7 @@ package outputs
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,8 +17,8 @@ import (
 
 // NewMQTTClient returns a new output.Client for accessing Kubernetes.
 func NewMQTTClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	options := mqtt.NewClientOptions()
 	options.AddBroker(config.MQTT.Broker)
 	options.SetClientID("falcosidekick-" + uuid.NewString()[:6])

--- a/outputs/mqtt.go
+++ b/outputs/mqtt.go
@@ -17,8 +17,8 @@ import (
 
 // NewMQTTClient returns a new output.Client for accessing Kubernetes.
 func NewMQTTClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	options := mqtt.NewClientOptions()
 	options.AddBroker(config.MQTT.Broker)
 	options.SetClientID("falcosidekick-" + uuid.NewString()[:6])

--- a/outputs/openfaas.go
+++ b/outputs/openfaas.go
@@ -21,8 +21,7 @@ import (
 
 // NewOpenfaasClient returns a new output.Client for accessing Kubernetes.
 func NewOpenfaasClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	if config.Openfaas.Kubeconfig != "" {
 		restConfig, err := clientcmd.BuildConfigFromFlags("", config.Openfaas.Kubeconfig)
 		if err != nil {

--- a/outputs/openfaas.go
+++ b/outputs/openfaas.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/client-go/kubernetes"
@@ -21,7 +21,8 @@ import (
 
 // NewOpenfaasClient returns a new output.Client for accessing Kubernetes.
 func NewOpenfaasClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	if config.Openfaas.Kubeconfig != "" {
 		restConfig, err := clientcmd.BuildConfigFromFlags("", config.Openfaas.Kubeconfig)
 		if err != nil {

--- a/outputs/otlp_logs.go
+++ b/outputs/otlp_logs.go
@@ -21,8 +21,7 @@ import (
 )
 
 func NewOtlpLogsClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	initClientArgs := &types.InitClientArgs{
 		Config:          config,
 		Stats:           stats,

--- a/outputs/otlp_logs.go
+++ b/outputs/otlp_logs.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
@@ -21,7 +21,8 @@ import (
 )
 
 func NewOtlpLogsClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	initClientArgs := &types.InitClientArgs{
 		Config:          config,
 		Stats:           stats,

--- a/outputs/otlp_traces.go
+++ b/outputs/otlp_traces.go
@@ -10,7 +10,7 @@ import (
 	"hash/fnv"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -24,7 +24,8 @@ import (
 var getTracerProvider = otel.GetTracerProvider
 
 func NewOtlpTracesClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	initClientArgs := &types.InitClientArgs{
 		Config:          config,
 		Stats:           stats,
@@ -72,7 +73,8 @@ func (c *Client) newTrace(falcopayload types.FalcoPayload) (*trace.Span, error) 
 		ctx,
 		falcopayload.Rule,
 		trace.WithTimestamp(startTime),
-		trace.WithSpanKind(trace.SpanKindServer))
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
 
 	span.SetAttributes(attribute.String("uuid", falcopayload.UUID))
 	span.SetAttributes(attribute.String("source", falcopayload.Source))

--- a/outputs/otlp_traces.go
+++ b/outputs/otlp_traces.go
@@ -24,8 +24,7 @@ import (
 var getTracerProvider = otel.GetTracerProvider
 
 func NewOtlpTracesClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	initClientArgs := &types.InitClientArgs{
 		Config:          config,
 		Stats:           stats,
@@ -73,8 +72,7 @@ func (c *Client) newTrace(falcopayload types.FalcoPayload) (*trace.Span, error) 
 		ctx,
 		falcopayload.Rule,
 		trace.WithTimestamp(startTime),
-		trace.WithSpanKind(trace.SpanKindServer),
-	)
+		trace.WithSpanKind(trace.SpanKindServer))
 
 	span.SetAttributes(attribute.String("uuid", falcopayload.UUID))
 	span.SetAttributes(attribute.String("source", falcopayload.Source))

--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -102,8 +102,7 @@ func newClusterPolicyReport() *wgpolicy.ClusterPolicyReport {
 }
 
 func NewPolicyReportClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	clientConfig, err := rest.InClusterConfig()
 	if err != nil {
 		clientConfig, err = clientcmd.BuildConfigFromFlags("", config.PolicyReport.Kubeconfig)
@@ -175,7 +174,7 @@ func (c *Client) UpdateOrCreatePolicyReport(falcopayload types.FalcoPayload) {
 
 // newResult creates a new entry for Reports
 func newResult(falcopayload types.FalcoPayload) *wgpolicy.PolicyReportResult {
-	properties := make(map[string]string)
+	var properties = make(map[string]string)
 	for i, j := range falcopayload.OutputFields {
 		properties[i] = toString(j)
 	}

--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
 	errorsv1 "k8s.io/apimachinery/pkg/api/errors"
@@ -102,7 +102,8 @@ func newClusterPolicyReport() *wgpolicy.ClusterPolicyReport {
 }
 
 func NewPolicyReportClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	clientConfig, err := rest.InClusterConfig()
 	if err != nil {
 		clientConfig, err = clientcmd.BuildConfigFromFlags("", config.PolicyReport.Kubeconfig)
@@ -174,7 +175,7 @@ func (c *Client) UpdateOrCreatePolicyReport(falcopayload types.FalcoPayload) {
 
 // newResult creates a new entry for Reports
 func newResult(falcopayload types.FalcoPayload) *wgpolicy.PolicyReportResult {
-	var properties = make(map[string]string)
+	properties := make(map[string]string)
 	for i, j := range falcopayload.OutputFields {
 		properties[i] = toString(j)
 	}

--- a/outputs/rabbitmq.go
+++ b/outputs/rabbitmq.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -18,8 +18,8 @@ import (
 
 // NewRabbitmqClient returns a new output.Client for accessing the RabbitmMQ API.
 func NewRabbitmqClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	var channel *amqp.Channel
 	if config.Rabbitmq.URL != "" && config.Rabbitmq.Queue != "" {
 		conn, err := amqp.Dial(config.Rabbitmq.URL)
@@ -57,7 +57,6 @@ func (c *Client) Publish(falcopayload types.FalcoPayload) {
 		ContentType: "text/plain",
 		Body:        payload,
 	})
-
 	if err != nil {
 		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("Error while publishing message: %v", err))
 		c.Stats.Rabbitmq.Add(Error, 1)

--- a/outputs/rabbitmq.go
+++ b/outputs/rabbitmq.go
@@ -18,8 +18,8 @@ import (
 
 // NewRabbitmqClient returns a new output.Client for accessing the RabbitmMQ API.
 func NewRabbitmqClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	var channel *amqp.Channel
 	if config.Rabbitmq.URL != "" && config.Rabbitmq.Queue != "" {
 		conn, err := amqp.Dial(config.Rabbitmq.URL)
@@ -57,6 +57,7 @@ func (c *Client) Publish(falcopayload types.FalcoPayload) {
 		ContentType: "text/plain",
 		Body:        payload,
 	})
+
 	if err != nil {
 		utils.Log(utils.ErrorLvl, c.OutputType, fmt.Sprintf("Error while publishing message: %v", err))
 		c.Stats.Rabbitmq.Add(Error, 1)

--- a/outputs/redis.go
+++ b/outputs/redis.go
@@ -30,8 +30,8 @@ func (c *Client) ReportError(err error) {
 }
 
 func NewRedisClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	var tlsCfg *tls.Config
 
 	if config.Redis.MutualTLS {

--- a/outputs/redis.go
+++ b/outputs/redis.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -30,8 +30,8 @@ func (c *Client) ReportError(err error) {
 }
 
 func NewRedisClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	var tlsCfg *tls.Config
 
 	if config.Redis.MutualTLS {

--- a/outputs/smtp.go
+++ b/outputs/smtp.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	textTemplate "text/template"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	sasl "github.com/emersion/go-sasl"
 	smtp "github.com/emersion/go-smtp"
 
@@ -34,7 +34,8 @@ type SMTPPayload struct {
 
 // NewSMTPClient returns a new output.Client for accessing a SMTP server.
 func NewSMTPClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	reg := regexp.MustCompile(`.*:[0-9]+`)
 	if !reg.MatchString(config.SMTP.HostPort) {
 		utils.Log(utils.ErrorLvl, "SMTP", "Bad Host:Port")

--- a/outputs/smtp.go
+++ b/outputs/smtp.go
@@ -34,8 +34,7 @@ type SMTPPayload struct {
 
 // NewSMTPClient returns a new output.Client for accessing a SMTP server.
 func NewSMTPClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	reg := regexp.MustCompile(`.*:[0-9]+`)
 	if !reg.MatchString(config.SMTP.HostPort) {
 		utils.Log(utils.ErrorLvl, "SMTP", "Bad Host:Port")

--- a/outputs/spyderbat.go
+++ b/outputs/spyderbat.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -22,12 +22,13 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
-const Falcosidekick_ string = "falcosidekick_"
-const SourcePath string = "/source/"
-const APIv1Path string = "api/v1/org/"
+const (
+	Falcosidekick_ string = "falcosidekick_"
+	SourcePath     string = "/source/"
+	APIv1Path      string = "api/v1/org/"
+)
 
 func isSourcePresent(config *types.Configuration) (bool, error) {
-
 	client := &http.Client{}
 
 	source_url, err := url.JoinPath(config.Spyderbat.APIUrl, APIv1Path+config.Spyderbat.OrgUID+SourcePath)
@@ -73,7 +74,6 @@ type SourceBody struct {
 }
 
 func makeSource(config *types.Configuration) error {
-
 	data := SourceBody{
 		Name:        config.Spyderbat.Source,
 		Description: config.Spyderbat.SourceDescription,
@@ -195,8 +195,8 @@ func newSpyderbatPayload(falcopayload types.FalcoPayload) (spyderbatPayload, err
 }
 
 func NewSpyderbatClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	hasSource, err := isSourcePresent(config)
 	if err != nil {
 		utils.Log(utils.ErrorLvl, "Spyderbat", err.Error())

--- a/outputs/spyderbat.go
+++ b/outputs/spyderbat.go
@@ -22,13 +22,12 @@ import (
 	"github.com/falcosecurity/falcosidekick/types"
 )
 
-const (
-	Falcosidekick_ string = "falcosidekick_"
-	SourcePath     string = "/source/"
-	APIv1Path      string = "api/v1/org/"
-)
+const Falcosidekick_ string = "falcosidekick_"
+const SourcePath string = "/source/"
+const APIv1Path string = "api/v1/org/"
 
 func isSourcePresent(config *types.Configuration) (bool, error) {
+
 	client := &http.Client{}
 
 	source_url, err := url.JoinPath(config.Spyderbat.APIUrl, APIv1Path+config.Spyderbat.OrgUID+SourcePath)
@@ -74,6 +73,7 @@ type SourceBody struct {
 }
 
 func makeSource(config *types.Configuration) error {
+
 	data := SourceBody{
 		Name:        config.Spyderbat.Source,
 		Description: config.Spyderbat.SourceDescription,
@@ -195,8 +195,8 @@ func newSpyderbatPayload(falcopayload types.FalcoPayload) (spyderbatPayload, err
 }
 
 func NewSpyderbatClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	hasSource, err := isSourcePresent(config)
 	if err != nil {
 		utils.Log(utils.ErrorLvl, "Spyderbat", err.Error())

--- a/outputs/statsd.go
+++ b/outputs/statsd.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"

--- a/outputs/statsd.go
+++ b/outputs/statsd.go
@@ -20,10 +20,10 @@ func NewStatsdClient(outputType string, config *types.Configuration, stats *type
 	var fwd string
 	switch outputType {
 	case "StatsD":
-		statsdClient, err = statsd.New(config.Statsd.Forwarder, statsd.WithNamespace(config.Statsd.Namespace), statsd.WithTags(config.Statsd.Tags))
+		statsdClient, err = statsd.New(config.Statsd.Forwarder, statsd.WithNamespace(config.Statsd.Namespace), statsd.WithTags(config.Statsd.Tags), statsd.WithoutOriginDetection())
 		fwd = config.Statsd.Forwarder
 	case "DogStatsD":
-		statsdClient, err = statsd.New(config.Dogstatsd.Forwarder, statsd.WithNamespace(config.Dogstatsd.Namespace), statsd.WithTags(config.Dogstatsd.Tags))
+		statsdClient, err = statsd.New(config.Dogstatsd.Forwarder, statsd.WithNamespace(config.Dogstatsd.Namespace), statsd.WithTags(config.Dogstatsd.Tags), statsd.WithoutOriginDetection())
 		fwd = config.Dogstatsd.Forwarder
 	}
 	if err != nil {

--- a/outputs/syslog.go
+++ b/outputs/syslog.go
@@ -18,8 +18,7 @@ import (
 )
 
 func NewSyslogClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
 	ok := isValidProtocolString(strings.ToLower(config.Syslog.Protocol))
 	if !ok {
 		return nil, fmt.Errorf("failed to configure Syslog client: invalid protocol %s", config.Syslog.Protocol)

--- a/outputs/syslog.go
+++ b/outputs/syslog.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/falcosecurity/falcosidekick/internal/pkg/utils"
@@ -18,7 +18,8 @@ import (
 )
 
 func NewSyslogClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	ok := isValidProtocolString(strings.ToLower(config.Syslog.Protocol))
 	if !ok {
 		return nil, fmt.Errorf("failed to configure Syslog client: invalid protocol %s", config.Syslog.Protocol)

--- a/outputs/timescaledb.go
+++ b/outputs/timescaledb.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/attribute"
 

--- a/outputs/wavefront.go
+++ b/outputs/wavefront.go
@@ -17,8 +17,8 @@ import (
 
 // NewWavefrontClient returns a new output.Client for accessing the Wavefront API.
 func NewWavefrontClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	var sender wavefront.Sender
 	var err error
 
@@ -67,6 +67,7 @@ func NewWavefrontClient(config *types.Configuration, stats *types.Statistics, pr
 
 // WavefrontPost sends metrics to WaveFront.
 func (c *Client) WavefrontPost(falcopayload types.FalcoPayload) {
+
 	tags := make(map[string]string)
 	tags["severity"] = falcopayload.Priority.String()
 	tags["rule"] = falcopayload.Rule
@@ -87,6 +88,7 @@ func (c *Client) WavefrontPost(falcopayload types.FalcoPayload) {
 
 	if len(falcopayload.Tags) != 0 {
 		tags["tags"] = strings.Join(falcopayload.Tags, ", ")
+
 	}
 
 	c.Stats.Wavefront.Add(Total, 1)

--- a/outputs/wavefront.go
+++ b/outputs/wavefront.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	wavefront "github.com/wavefronthq/wavefront-sdk-go/senders"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -17,8 +17,8 @@ import (
 
 // NewWavefrontClient returns a new output.Client for accessing the Wavefront API.
 func NewWavefrontClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	var sender wavefront.Sender
 	var err error
 
@@ -67,7 +67,6 @@ func NewWavefrontClient(config *types.Configuration, stats *types.Statistics, pr
 
 // WavefrontPost sends metrics to WaveFront.
 func (c *Client) WavefrontPost(falcopayload types.FalcoPayload) {
-
 	tags := make(map[string]string)
 	tags["severity"] = falcopayload.Priority.String()
 	tags["rule"] = falcopayload.Rule
@@ -88,7 +87,6 @@ func (c *Client) WavefrontPost(falcopayload types.FalcoPayload) {
 
 	if len(falcopayload.Tags) != 0 {
 		tags["tags"] = strings.Join(falcopayload.Tags, ", ")
-
 	}
 
 	c.Stats.Wavefront.Add(Total, 1)

--- a/outputs/yandex.go
+++ b/outputs/yandex.go
@@ -25,12 +25,11 @@ import (
 
 // NewYandexClient returns a new output.Client for accessing the Yandex API.
 func NewYandexClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
-) (*Client, error) {
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
+
 	// Load the SDK's configuration from environment and shared config, and
 	// create the client with this.
-	cfg, err := awsConfig.LoadDefaultConfig(
-		context.Background(),
+	cfg, err := awsConfig.LoadDefaultConfig(context.Background(),
 		awsConfig.WithRegion(config.Yandex.Region),
 		awsConfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(config.Yandex.AccessKeyID, config.Yandex.SecretAccessKey, "")),
 	)

--- a/outputs/yandex.go
+++ b/outputs/yandex.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -25,11 +25,12 @@ import (
 
 // NewYandexClient returns a new output.Client for accessing the Yandex API.
 func NewYandexClient(config *types.Configuration, stats *types.Statistics, promStats *types.PromStatistics,
-	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client) (*Client, error) {
-
+	otlpMetrics *otlpmetrics.OTLPMetrics, statsdClient, dogstatsdClient *statsd.Client,
+) (*Client, error) {
 	// Load the SDK's configuration from environment and shared config, and
 	// create the client with this.
-	cfg, err := awsConfig.LoadDefaultConfig(context.Background(),
+	cfg, err := awsConfig.LoadDefaultConfig(
+		context.Background(),
 		awsConfig.WithRegion(config.Yandex.Region),
 		awsConfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(config.Yandex.AccessKeyID, config.Yandex.SecretAccessKey, "")),
 	)

--- a/types/types.go
+++ b/types/types.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/embano1/memlog"
 	"github.com/prometheus/client_golang/prometheus"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind cleanup

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area outputs

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Upgrade `github.com/DataDog/datadog-go` to `v5` and disable origin detection.

### Behavioral Changes & Important Notes in `datadog-go/v5`
#### 1. Client-side Aggregation (Kept default: Enabled)
In `datadog-go/v5`, client-side aggregation is enabled by default. Metric samples sharing the same name and tags are summed locally over a 2-second window before flushing (e.g., `falcosidekick.outputs.slack.ok:3|c` instead of 3 individual `:1|c` datagrams).
- **Impact**: Overall counter totals remain unchanged, while significantly reducing UDP packet traffic and network overhead.
- **Note for operators**: Flushed metrics will have a slightly coarser time resolution (up to a 2s aggregation interval).
#### 2. Disabled Origin Detection (`statsd.WithoutOriginDetection()`)
In `v5`, origin detection is enabled by default (auto-discovering container IDs via `/proc/self/cgroup` and appending `|c:<container-id>` to packets). This has been explicitly disabled for both StatsD and DogStatsD in `outputs/statsd.go` for the following reasons:
- **Prevents metric drops on StatsD / `statsd_exporter`**: Plain StatsD datagrams do not contain a `|#` tag section. Metric collectors such as `prometheus/statsd_exporter` (>= v0.29.0) treat everything after the first colon as colon-separated multi-metrics; the colon in `|c:<container-id>` causes the exporter to reject the metric (`DROPPED (malformed_container_id)`), leading to silent metric loss.
- **Avoids cardinality churn on DogStatsD**: Prevents attaching dynamic `container_id` labels that change with every pod restart.
- **Applied to both clients**: `statsd.WithoutOriginDetection()` is passed to both `StatsD` and `DogStatsD` initializations because `datadog-go` caches container ID discovery in a package-level global guarded by `sync.Once`. Disabling it only on one client would result in race conditions depending on initialization order.
