### PR TITLE
Handle numeric output_fields without a string assertion

### DIFF
--- a/outputs/alertmanager.go
+++ b/outputs/alertmanager.go
@@ -74,7 +74,10 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 		}
 		// strip cardinalities of syscall drops
 		if strings.HasPrefix(i, "n_drop") {
-			d, err := strconv.ParseInt(j.(string), 10, 64)
+			// the payload decoder runs with UseNumber, so a numeric value arrives
+			// as json.Number rather than a string
+			sj := toString(j)
+			d, err := strconv.ParseInt(sj, 10, 64)
 			if err == nil {
 				var jj string
 				if d == 0 {
@@ -94,7 +97,7 @@ func newAlertmanagerPayload(falcopayload types.FalcoPayload, config *types.Confi
 					}
 				}
 				if jj == "" {
-					jj = j.(string)
+					jj = sj
 					if prio := types.Priority(config.Alertmanager.DropEventDefaultPriority); falcopayload.Priority < prio {
 						falcopayload.Priority = prio
 					}

--- a/outputs/alertmanager_test.go
+++ b/outputs/alertmanager_test.go
@@ -131,3 +131,26 @@ func Test_alertmanagerSafeLabel(t *testing.T) {
 		})
 	}
 }
+
+// Falco sends n_drops as a JSON number, not a string. newFalcoPayload decodes
+// with UseNumber, so the value arrives as json.Number and a type assertion to
+// string panics. Every other drop-event test quotes the value, which is why
+// this path was never covered.
+func TestNewAlertmanagerPayloadDropEventNumericFields(t *testing.T) {
+	input := `{"hostname":"host","output":"Falco internal: syscall event drop. 815508 system calls dropped in last second.","output_fields":{"n_drops":815508,"n_drops_buffer_total":815508,"n_drops_bug":0,"n_evts":2270350},"priority":"Debug","rule":"Falco internal: syscall event drop","time":"2023-03-03T03:03:03.000000003Z"}`
+	var f types.FalcoPayload
+	d := json.NewDecoder(strings.NewReader(input))
+	d.UseNumber()
+	require.Nil(t, d.Decode(&f))
+
+	config := &types.Configuration{
+		Alertmanager: types.AlertmanagerOutputConfig{DropEventDefaultPriority: Critical},
+	}
+	json.Unmarshal([]byte(defaultThresholds), &config.Alertmanager.DropEventThresholdsList)
+
+	o := newAlertmanagerPayload(f, config)
+	require.Len(t, o, 1)
+	require.Equal(t, ">10000", o[0].Labels["n_drops"])
+	require.Equal(t, ">10000", o[0].Labels["n_drops_buffer_total"])
+	require.Equal(t, "0", o[0].Labels["n_drops_bug"])
+}

--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -394,7 +394,7 @@ func getResourceNameKind(outputFields map[string]interface{}) (string, string) {
 		return toString(outputFields[kaTargetName]), toString(outputFields[kaTargetResource])
 	}
 	if outputFields[kaRespName] != nil {
-		return toString(outputFields[kaRespName].(string)), toString(outputFields[kaTargetResource])
+		return toString(outputFields[kaRespName]), toString(outputFields[kaTargetResource])
 	}
 
 	return "", ""


### PR DESCRIPTION
`newFalcoPayload` decodes the incoming alert with `d.UseNumber()` (`handlers.go:102`), so a JSON number in `output_fields` arrives as `json.Number`, never as a `string`. Two places assert it to `string` anyway.

`outputs/alertmanager.go` does it while stripping drop cardinalities, so a syscall-drop alert whose `n_drops` is unquoted panics:

```
interface conversion: interface {} is json.Number, not string
  outputs.newAlertmanagerPayload ... outputs/alertmanager.go:77
```

Falco emits that field as a number. Every existing drop-event test quotes it (`"n_drops":"815508"`), which is why the path has never been exercised even though those tests do call `UseNumber`.

`outputs/policyreport.go:397` has the same shape on `ka.resp.name`, where a numeric value gives `is float64, not string`. Both now go through the package's own `toString`, which the lines immediately around them already use.

Worth being precise about the impact: outputs are dispatched through `safeGo` (`handlers.go:589`), which recovers, so the process stays up. The consequence is that the alert is silently dropped rather than delivered, not a crash of falcosidekick.

Added a drop-event test with unquoted numeric fields. It panics without the change, and asserts the `>10000` and `0` labels come out the same as the quoted equivalent.
