### PR TITLE
Add OTLP documentation for Falcosidekick

### DIFF
--- a/docs/outputs/otlp.md
+++ b/docs/outputs/otlp.md
@@ -1,0 +1,49 @@
+# OTLP (OpenTelemetry Protocol)
+
+- **Category**: Traces, Logs, Metrics
+- **Website**: <https://opentelemetry.io/>
+
+## Table of content
+
+- [OTLP (OpenTelemetry Protocol)](#otlp-opentelemetry-protocol)
+  - [Table of content](#table-of-content)
+  - [Overview](#overview)
+  - [Signals](#signals)
+    - [Traces](#traces)
+    - [Logs](#logs)
+    - [Metrics](#metrics)
+  - [Additional info](#additional-info)
+
+## Overview
+
+Falcosidekick can export Falco events directly via [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/), using the official OpenTelemetry Go SDK and exporters (`go.opentelemetry.io/otel`). This lets you forward Falco security events to any OTLP-compatible collector or backend (Grafana Tempo/Loki/Mimir, Prometheus, Jaeger, Datadog, and others) without an intermediate translation layer.
+
+OTLP support is split into three independent signals, each configured and documented on its own page:
+
+## Signals
+
+### Traces
+
+Forwards Falco events as OTLP traces (with an artificial span duration, since Falco events don't carry an end timestamp).
+
+See [OTEL Traces](otlp_traces.md) for configuration, `config.yaml` example, and a full docker-compose stack (Falco + Falcosidekick + Grafana Tempo + Grafana).
+
+### Logs
+
+Forwards Falco events as OTLP log records.
+
+See [OTEL Logs](otlp_logs.md) for configuration and setup details.
+
+### Metrics
+
+Exposes counters/metrics about Falco events via OTLP metrics, in addition to Falcosidekick's existing Prometheus/StatsD outputs.
+
+See [OTEL Metrics](otlp_metrics.md) for configuration and a full docker-compose stack (Falco + Falcosidekick + OpenTelemetry Collector + Prometheus).
+
+## Additional info
+
+> [!NOTE]
+Each signal (traces, logs, metrics) is enabled independently by setting its `endpoint` — you can enable one, two, or all three at once.
+
+> [!WARNING]
+Because of the way the OTEL SDK is structured, the OTLP outputs don't appear in Falcosidekick's own metrics (Prometheus, StatsD, ...) and error logs just specify `OTEL` as the output.


### PR DESCRIPTION
Document the OpenTelemetry Protocol (OTLP) support in Falcosidekick, including details on traces, logs, and metrics.

**What type of PR is this?**
/kind documentation

**Any specific area of the project related to this PR?**
/area outputs

**What this PR does / why we need it**:
Adds a new `docs/outputs/otlp.md` overview page that ties together the three existing OTLP output docs (`otlp_traces.md`, `otlp_logs.md`, `otlp_metrics.md`) under a single entry point. This page is needed as the canonical `docs` reference for an upcoming Falcosidekick entry in the OpenTelemetry Ecosystem Registry (see falcosecurity/falcosidekick#1376), which requires a single URL describing the OTLP integration rather than three separate signal-specific pages.

**Which issue(s) this PR fixes**:
Related #1376

**Special notes for your reviewer**:
This PR only adds documentation, no code changes. Confirmed with @Issif in #1376 that:
- A new page referencing the three existing OTLP docs is the preferred approach (rather than picking one of the three as canonical)
- The OTLP integration is native (uses the official OpenTelemetry Go SDK/exporters per `go.mod`, not a hand-rolled implementation)

Once this is merged, I'll open a follow-up PR to `open-telemetry/opentelemetry.io` adding the registry entry, pointing its `docs` field at this new page.

Preview of the registry entry :
<img width="1792" height="625" alt="image" src="https://github.com/user-attachments/assets/2c06af16-2a13-4d98-90fe-709b07c709f1" />
