### PR TITLE
Do not assert output_fields values are strings

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -95,6 +95,27 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 	mainHandler(w, r)
 }
 
+// kubernetesFields picks the namespace and pod name out of output_fields.
+//
+// The map is decoded straight from the request body, so a field can hold any
+// JSON value. A non-string is ignored rather than asserted, since a bare
+// j.(string) panics on a number, object, list or bool.
+func kubernetesFields(outputFields map[string]interface{}) (namespace, pod string) {
+	for k, v := range outputFields {
+		if v == nil {
+			continue
+		}
+		switch k {
+		case "k8s.ns.name":
+			namespace, _ = v.(string)
+		case "k8s.pod.name":
+			pod, _ = v.(string)
+		}
+	}
+
+	return namespace, pod
+}
+
 func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 	var falcopayload types.FalcoPayload
 
@@ -129,17 +150,7 @@ func newFalcoPayload(payload io.Reader) (types.FalcoPayload, error) {
 
 	falcopayload.UUID = uuid.New().String()
 
-	var kn, kp string
-	for i, j := range falcopayload.OutputFields {
-		if j != nil {
-			if i == "k8s.ns.name" {
-				kn = j.(string)
-			}
-			if i == "k8s.pod.name" {
-				kp = j.(string)
-			}
-		}
-	}
+	kn, kp := kubernetesFields(falcopayload.OutputFields)
 
 	var templatedFields string
 	if len(config.Templatedfields) > 0 {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,55 @@
+package main
+
+import "testing"
+
+func TestKubernetesFieldsIgnoresNonStringValues(t *testing.T) {
+	// output_fields is decoded from the request body, so a field can hold any
+	// JSON value. A bare j.(string) panicked on all of these.
+	tests := map[string]map[string]interface{}{
+		"namespace as a number":  {"k8s.ns.name": 42},
+		"pod as a number":        {"k8s.pod.name": 42},
+		"namespace as an object": {"k8s.ns.name": map[string]interface{}{"a": 1}},
+		"pod as a list":          {"k8s.pod.name": []interface{}{"a"}},
+		"namespace as a bool":    {"k8s.ns.name": true},
+		"nil value":              {"k8s.ns.name": nil},
+	}
+
+	for name, outputFields := range tests {
+		t.Run(name, func(t *testing.T) {
+			namespace, pod := kubernetesFields(outputFields)
+
+			if namespace != "" || pod != "" {
+				t.Fatalf("expected both empty, got namespace=%q pod=%q", namespace, pod)
+			}
+		})
+	}
+}
+
+func TestKubernetesFieldsKeepsStringValues(t *testing.T) {
+	namespace, pod := kubernetesFields(map[string]interface{}{
+		"k8s.ns.name":  "kube-system",
+		"k8s.pod.name": "falco-abcde",
+		"proc.name":    "falco",
+	})
+
+	if namespace != "kube-system" {
+		t.Fatalf("namespace: got %q", namespace)
+	}
+	if pod != "falco-abcde" {
+		t.Fatalf("pod: got %q", pod)
+	}
+}
+
+func TestKubernetesFieldsKeepsAStringWhenTheOtherIsNot(t *testing.T) {
+	namespace, pod := kubernetesFields(map[string]interface{}{
+		"k8s.ns.name":  "kube-system",
+		"k8s.pod.name": 42,
+	})
+
+	if namespace != "kube-system" {
+		t.Fatalf("namespace: got %q", namespace)
+	}
+	if pod != "" {
+		t.Fatalf("pod: got %q", pod)
+	}
+}


### PR DESCRIPTION
`newFalcoPayload` pulled the Kubernetes namespace and pod out of `output_fields` with a bare type assertion (`handlers.go:133-142` before this change):

```go
var kn, kp string
for i, j := range falcopayload.OutputFields {
    if j != nil {
        if i == "k8s.ns.name" {
            kn = j.(string)
        }
        if i == "k8s.pod.name" {
            kp = j.(string)
        }
    }
}
```

`OutputFields` is `map[string]interface{}` decoded straight from the request body, so a field can hold any JSON value. The `j != nil` guard only rules out `null`. Driving the real function with a crafted body:

```
namespace as a number -> PANIC: interface conversion: interface {} is json.Number, not string
pod as an object      -> PANIC: interface conversion: interface {} is map[string]interface {}, not string
```

Being precise about the impact rather than overstating it: `net/http` recovers a handler panic per connection, so this aborts that one request and closes the connection rather than stopping the process. The event is dropped and the sender gets nothing back. It needs a producer that puts a non-string in one of those two fields, which Falco itself does not do, but the endpoint accepts whatever is posted to it.

The lookup now lives in `kubernetesFields`, using the comma-ok form so a non-string leaves the value empty instead of panicking.

I pulled it into its own function rather than fixing the assertion in place, because testing it through `newFalcoPayload` meant initialising `stats`, `promStats` and `nullClient` the way `main` does, and `getInitPromStats` then registers collectors that collide with `TestFalcoNewCounterVec` in `stats_prometheus_test.go`. A helper keeps the test free of package globals. Happy to inline it again if you would rather.

Three tests: every non-string shape plus `nil`, both fields preserved when they are strings, and one string kept when the other is not, so this cannot pass by discarding both. All of them panic on `master`. `go build ./...`, `go vet .` and `go test ./...` are clean.
