### PR TITLE
fix(outputs): use Unix epoch seconds for PolicyReport timestamps

### DIFF
--- a/outputs/policyreport.go
+++ b/outputs/policyreport.go
@@ -184,7 +184,7 @@ func newResult(falcopayload types.FalcoPayload) *wgpolicy.PolicyReportResult {
 		Rule:        falcopayload.Rule,
 		Category:    "SI - System and Information Integrity",
 		Source:      policyReportSource,
-		Timestamp:   metav1.Timestamp{Seconds: int64(falcopayload.Time.Second()), Nanos: int32(falcopayload.Time.Nanosecond())}, //nolint:gosec // disable G115
+		Timestamp:   metav1.Timestamp{Seconds: falcopayload.Time.Unix(), Nanos: int32(falcopayload.Time.Nanosecond())}, //nolint:gosec // disable G115
 		Severity:    mapSeverity(falcopayload),
 		Result:      mapResult(falcopayload),
 		Description: falcopayload.Output,

--- a/outputs/policyreport_test.go
+++ b/outputs/policyreport_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package outputs
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/falcosecurity/falcosidekick/types"
+)
+
+func TestNewResultTimestamp(t *testing.T) {
+	var f types.FalcoPayload
+	require.Nil(t, json.Unmarshal([]byte(falcoTestInput), &f))
+
+	result := newResult(f)
+
+	// falcoTestInput carries 2001-01-01T01:10:00Z, which is 978311400 seconds
+	// since the Unix epoch.
+	require.Equal(t, int64(978311400), result.Timestamp.Seconds)
+	require.Equal(t, int32(0), result.Timestamp.Nanos)
+
+	// The event time has to survive the round trip into the PolicyReport
+	// result: consumers use this field to order events and to decide whether
+	// a result is too old to accept.
+	require.Equal(t, f.Time.UTC(), time.Unix(result.Timestamp.Seconds, int64(result.Timestamp.Nanos)).UTC())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area outputs

/area tests

**What this PR does / why we need it**:

`newResult` in the `policyreport` output filled `metav1.Timestamp.Seconds` from `time.Time.Second()`, which returns the second within the minute (0-59) rather than the seconds since the Unix epoch. Every result written to a `PolicyReport` or `ClusterPolicyReport` was therefore stamped somewhere in the first minute of 1 January 1970.

```diff
-Seconds: int64(falcopayload.Time.Second()),
+Seconds: falcopayload.Time.Unix(),
```

`Nanos` was already correct and is unchanged.

The effect is not cosmetic, because downstream consumers use this field as the event time. Policy Reporter, for instance, compares it against its own start time when `skipExistingOnStartup` is enabled and drops anything older, and its Loki target writes the log line at that timestamp, where Loki rejects it under `reject_old_samples_max_age` (7 days by default). Nothing errors along the way, so results are produced, accepted by the API server, and then quietly ignored.

**Which issue(s) this PR fixes**:

Fixes #1424

**Special notes for your reviewer**:

The regression test uses the existing `falcoTestInput` fixture, whose event time is `2001-01-01T01:10:00Z` (978311400 epoch seconds). It fails before the change with `expected: 978311400, actual: 0` and passes after it. `go test ./outputs/` stays green as a whole.

Worth noting that the buggy value is bounded by 0-59, so on a live cluster the symptom shows up as exactly sixty distinct timestamps spread across the first minute of 1970 — which is what made it easy to identify. Details are in #1424.
